### PR TITLE
FIX security header of inner NAS message

### DIFF
--- a/gmm/gmm_message/build.go
+++ b/gmm/gmm_message/build.go
@@ -314,7 +314,7 @@ func BuildSecurityModeCommand(ue *amf_context.AmfUe, eapSuccess bool, eapMessage
 
 	securityModeCommand := nasMessage.NewSecurityModeCommand(0)
 	securityModeCommand.ExtendedProtocolDiscriminator.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
-	securityModeCommand.SpareHalfOctetAndSecurityHeaderType.SetSecurityHeaderType(nas.SecurityHeaderTypeIntegrityProtectedWithNew5gNasSecurityContext)
+	securityModeCommand.SpareHalfOctetAndSecurityHeaderType.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
 	securityModeCommand.SpareHalfOctetAndSecurityHeaderType.SetSpareHalfOctet(0)
 	securityModeCommand.SecurityModeCommandMessageIdentity.SetMessageType(nas.MsgTypeSecurityModeCommand)
 


### PR DESCRIPTION
For security Protected NAS messages the Security Header Type IE of the Plain 5GS NAS message has to be set to Plain.

TS 24.501: 8.2.28.1 and 9.9

This IE includes a complete plain 5GS NAS message as specified in subclauses 8.2 and 8.3. The SECURITY PROTECTED 5GS NAS MESSAGE message (see subclause 8.2.28) is not plain 5GS NAS messages and shall not be included in this IE.