### PR TITLE
[ADD] Added ServerIPv4 config field.

### DIFF
--- a/consumer/nf_mangement.go
+++ b/consumer/nf_mangement.go
@@ -50,7 +50,7 @@ func BuildNFInstance(context *amf_context.AMFContext) (profile models.NfProfile,
 		err = fmt.Errorf("AMF Address is empty")
 		return
 	}
-	profile.Ipv4Addresses = append(profile.Ipv4Addresses, context.ServiceIPv4)
+	profile.Ipv4Addresses = append(profile.Ipv4Addresses, context.HttpIPv4Address)
 	service := []models.NfService{}
 	for _, nfService := range context.NfService {
 		service = append(service, nfService)

--- a/consumer/nf_mangement.go
+++ b/consumer/nf_mangement.go
@@ -50,7 +50,7 @@ func BuildNFInstance(context *amf_context.AMFContext) (profile models.NfProfile,
 		err = fmt.Errorf("AMF Address is empty")
 		return
 	}
-	profile.Ipv4Addresses = append(profile.Ipv4Addresses, context.HttpIPv4Address)
+	profile.Ipv4Addresses = append(profile.Ipv4Addresses, context.ServiceIPv4)
 	service := []models.NfService{}
 	for _, nfService := range context.NfService {
 		service = append(service, nfService)

--- a/context/context.go
+++ b/context/context.go
@@ -58,6 +58,7 @@ type AMFContext struct {
 	HttpIpv4Port                     int
 	HttpIPv4Address                  string
 	HttpIPv6Address                  string
+	ServerIPv4						 string
 	TNLWeightFactor                  int64
 	SupportDnnLists                  []string
 	AMFStatusSubscriptionIDGenerator int
@@ -315,6 +316,7 @@ func (context *AMFContext) Reset() {
 	context.HttpIpv4Port = 0
 	context.HttpIPv4Address = ""
 	context.HttpIPv6Address = ""
+	context.ServerIPv4 = ""
 	context.Name = "amf"
 	context.NrfUri = ""
 	TmsiGenerator = 0

--- a/context/context.go
+++ b/context/context.go
@@ -58,7 +58,7 @@ type AMFContext struct {
 	HttpIpv4Port                     int
 	HttpIPv4Address                  string
 	HttpIPv6Address                  string
-	ServerIPv4						 string
+	ServiceIPv4                      string
 	TNLWeightFactor                  int64
 	SupportDnnLists                  []string
 	AMFStatusSubscriptionIDGenerator int
@@ -246,7 +246,7 @@ func (context *AMFContext) RanUeFindByAmfUeNgapID(amfUeNgapID int64) *RanUe {
 }
 
 func (context *AMFContext) GetIPv4Uri() string {
-	return fmt.Sprintf("%s://%s:%d", context.UriScheme, context.HttpIPv4Address, context.HttpIpv4Port)
+	return fmt.Sprintf("%s://%s:%d", context.UriScheme, context.ServiceIPv4, context.HttpIpv4Port)
 }
 
 func (context *AMFContext) InitNFService(serivceName []string, version string) {
@@ -268,7 +268,7 @@ func (context *AMFContext) InitNFService(serivceName []string, version string) {
 			ApiPrefix:       context.GetIPv4Uri(),
 			IpEndPoints: &[]models.IpEndPoint{
 				{
-					Ipv4Address: context.HttpIPv4Address,
+					Ipv4Address: context.ServiceIPv4,
 					Transport:   models.TransportProtocol_TCP,
 					Port:        int32(context.HttpIpv4Port),
 				},
@@ -316,7 +316,7 @@ func (context *AMFContext) Reset() {
 	context.HttpIpv4Port = 0
 	context.HttpIPv4Address = ""
 	context.HttpIPv6Address = ""
-	context.ServerIPv4 = ""
+	context.ServiceIPv4 = ""
 	context.Name = "amf"
 	context.NrfUri = ""
 	TmsiGenerator = 0

--- a/context/context.go
+++ b/context/context.go
@@ -58,7 +58,7 @@ type AMFContext struct {
 	HttpIpv4Port                     int
 	HttpIPv4Address                  string
 	HttpIPv6Address                  string
-	ServiceIPv4                      string
+	ServerIPv4                       string
 	TNLWeightFactor                  int64
 	SupportDnnLists                  []string
 	AMFStatusSubscriptionIDGenerator int
@@ -246,7 +246,7 @@ func (context *AMFContext) RanUeFindByAmfUeNgapID(amfUeNgapID int64) *RanUe {
 }
 
 func (context *AMFContext) GetIPv4Uri() string {
-	return fmt.Sprintf("%s://%s:%d", context.UriScheme, context.ServiceIPv4, context.HttpIpv4Port)
+	return fmt.Sprintf("%s://%s:%d", context.UriScheme, context.HttpIPv4Address, context.HttpIpv4Port)
 }
 
 func (context *AMFContext) InitNFService(serivceName []string, version string) {
@@ -268,7 +268,7 @@ func (context *AMFContext) InitNFService(serivceName []string, version string) {
 			ApiPrefix:       context.GetIPv4Uri(),
 			IpEndPoints: &[]models.IpEndPoint{
 				{
-					Ipv4Address: context.ServiceIPv4,
+					Ipv4Address: context.HttpIPv4Address,
 					Transport:   models.TransportProtocol_TCP,
 					Port:        int32(context.HttpIpv4Port),
 				},
@@ -316,7 +316,7 @@ func (context *AMFContext) Reset() {
 	context.HttpIpv4Port = 0
 	context.HttpIPv4Address = ""
 	context.HttpIPv6Address = ""
-	context.ServiceIPv4 = ""
+	context.ServerIPv4 = ""
 	context.Name = "amf"
 	context.NrfUri = ""
 	TmsiGenerator = 0

--- a/factory/config.go
+++ b/factory/config.go
@@ -24,6 +24,8 @@ type Info struct {
 type Configuration struct {
 	AmfName string `yaml:"amfName,omitempty"`
 
+	ServerIPv4 string `yaml:"serverIPv4,omitempty"`
+
 	NgapIpList []string `yaml:"ngapIpList,omitempty"`
 
 	Sbi *Sbi `yaml:"sbi,omitempty"`

--- a/factory/config.go
+++ b/factory/config.go
@@ -24,7 +24,7 @@ type Info struct {
 type Configuration struct {
 	AmfName string `yaml:"amfName,omitempty"`
 
-	ServiceIPv4 string `yaml:"serviceIPv4,omitempty"`
+	ServerIPv4 string `yaml:"serverIPv4,omitempty"`
 
 	NgapIpList []string `yaml:"ngapIpList,omitempty"`
 

--- a/factory/config.go
+++ b/factory/config.go
@@ -24,7 +24,7 @@ type Info struct {
 type Configuration struct {
 	AmfName string `yaml:"amfName,omitempty"`
 
-	ServiceIPv4 string `yaml:"serverIPv4,omitempty"`
+	ServiceIPv4 string `yaml:"serviceIPv4,omitempty"`
 
 	NgapIpList []string `yaml:"ngapIpList,omitempty"`
 

--- a/factory/config.go
+++ b/factory/config.go
@@ -24,7 +24,7 @@ type Info struct {
 type Configuration struct {
 	AmfName string `yaml:"amfName,omitempty"`
 
-	ServerIPv4 string `yaml:"serverIPv4,omitempty"`
+	ServiceIPv4 string `yaml:"serverIPv4,omitempty"`
 
 	NgapIpList []string `yaml:"ngapIpList,omitempty"`
 

--- a/service/amf_init.go
+++ b/service/amf_init.go
@@ -137,7 +137,7 @@ func (amf *AMF) Start() {
 	self := context.AMF_Self()
 	util.InitAmfContext(self)
 
-	addr := fmt.Sprintf("%s:%d", self.ServerIPv4, self.HttpIpv4Port)
+	addr := fmt.Sprintf("%s:%d", self.HttpIPv4Address, self.HttpIpv4Port)
 
 	for _, ngapAddr := range self.NgapIpList {
 		sctpListener = sctp.Server(ngapAddr)

--- a/service/amf_init.go
+++ b/service/amf_init.go
@@ -137,7 +137,7 @@ func (amf *AMF) Start() {
 	self := context.AMF_Self()
 	util.InitAmfContext(self)
 
-	addr := fmt.Sprintf("%s:%d", self.HttpIPv4Address, self.HttpIpv4Port)
+	addr := fmt.Sprintf("%s:%d", self.ServerIPv4, self.HttpIpv4Port)
 
 	for _, ngapAddr := range self.NgapIpList {
 		sctpListener = sctp.Server(ngapAddr)

--- a/util/init_context.go
+++ b/util/init_context.go
@@ -7,6 +7,7 @@ import (
 	"free5gc/src/amf/factory"
 	"free5gc/src/amf/logger"
 	"github.com/google/uuid"
+	"os"
 )
 
 func InitAmfContext(context *context.AMFContext) {
@@ -17,6 +18,17 @@ func InitAmfContext(context *context.AMFContext) {
 	if configuration.AmfName != "" {
 		context.Name = configuration.AmfName
 	}
+
+	context.ServerIPv4 = os.Getenv(configuration.ServerIPv4)
+	if context.ServerIPv4 == "" {
+		logger.UtilLog.Warn("Problem parsing ServerIPv4 address from ENV Variable. Trying to parse it as string.")
+		context.ServerIPv4 = configuration.ServerIPv4
+		if context.ServerIPv4 == "" {
+			logger.UtilLog.Warn("Error parsing ServerIPv4 address as string. Using the localhost address as default.")
+			context.ServerIPv4 = "127.0.0.1"
+		}
+	}
+
 	if configuration.NgapIpList != nil {
 		context.NgapIpList = configuration.NgapIpList
 	} else {

--- a/util/init_context.go
+++ b/util/init_context.go
@@ -18,9 +18,15 @@ func InitAmfContext(context *context.AMFContext) {
 	if configuration.AmfName != "" {
 		context.Name = configuration.AmfName
 	}
-
-	context.ServiceIPv4 = configuration.ServiceIPv4
-
+	context.ServerIPv4 = os.Getenv(configuration.ServerIPv4)
+	if context.ServerIPv4 == "" {
+		logger.UtilLog.Warn("Problem parsing ServerIPv4 address from ENV Variable. Trying to parse it as string.")
+		context.ServerIPv4 = configuration.ServerIPv4
+		if context.ServerIPv4 == "" {
+			logger.UtilLog.Warn("Error parsing ServerIPv4 address as string. Using the localhost address as default.")
+			context.ServerIPv4 = "127.0.0.1"
+		}
+	}
 	if configuration.NgapIpList != nil {
 		context.NgapIpList = configuration.NgapIpList
 	} else {
@@ -32,14 +38,7 @@ func InitAmfContext(context *context.AMFContext) {
 	context.HttpIpv4Port = 29518          // default port
 	if sbi != nil {
 		if sbi.IPv4Addr != "" {
-			if os.Getenv(sbi.IPv4Addr) != "" {
-				context.HttpIPv4Address = os.Getenv(sbi.IPv4Addr)
-			} else {
-				logger.UtilLog.Warn("Problem parsing ServerIPv4 address from ENV Variable. Parsing it as plain string...")
-				context.HttpIPv4Address = sbi.IPv4Addr
-			}
-		} else {
-			logger.UtilLog.Warn("Error parsing ServerIPv4 address as string. Using the localhost address as default.")
+			context.HttpIPv4Address = sbi.IPv4Addr
 		}
 		if sbi.Port != 0 {
 			context.HttpIpv4Port = sbi.Port
@@ -57,7 +56,8 @@ func InitAmfContext(context *context.AMFContext) {
 	if configuration.NrfUri != "" {
 		context.NrfUri = configuration.NrfUri
 	} else {
-		context.NrfUri = fmt.Sprintf("%s://%s:%d", context.UriScheme, context.HttpIPv4Address, 29510)
+		logger.UtilLog.Warn("NRF Uri is empty! Using localhost as NRF IPv4 address.")
+		context.NrfUri = fmt.Sprintf("%s://%s:%d", context.UriScheme, "127.0.0.1", 29510)
 	}
 	security := configuration.Security
 	if security != nil {

--- a/util/init_context.go
+++ b/util/init_context.go
@@ -19,15 +19,7 @@ func InitAmfContext(context *context.AMFContext) {
 		context.Name = configuration.AmfName
 	}
 
-	context.ServerIPv4 = os.Getenv(configuration.ServerIPv4)
-	if context.ServerIPv4 == "" {
-		logger.UtilLog.Warn("Problem parsing ServerIPv4 address from ENV Variable. Trying to parse it as string.")
-		context.ServerIPv4 = configuration.ServerIPv4
-		if context.ServerIPv4 == "" {
-			logger.UtilLog.Warn("Error parsing ServerIPv4 address as string. Using the localhost address as default.")
-			context.ServerIPv4 = "127.0.0.1"
-		}
-	}
+	context.ServiceIPv4 = configuration.ServiceIPv4
 
 	if configuration.NgapIpList != nil {
 		context.NgapIpList = configuration.NgapIpList
@@ -40,7 +32,14 @@ func InitAmfContext(context *context.AMFContext) {
 	context.HttpIpv4Port = 29518          // default port
 	if sbi != nil {
 		if sbi.IPv4Addr != "" {
-			context.HttpIPv4Address = sbi.IPv4Addr
+			if os.Getenv(sbi.IPv4Addr) != "" {
+				context.HttpIPv4Address = os.Getenv(sbi.IPv4Addr)
+			} else {
+				logger.UtilLog.Warn("Problem parsing ServerIPv4 address from ENV Variable. Parsing it as plain string...")
+				context.HttpIPv4Address = sbi.IPv4Addr
+			}
+		} else {
+			logger.UtilLog.Warn("Error parsing ServerIPv4 address as string. Using the localhost address as default.")
 		}
 		if sbi.Port != 0 {
 			context.HttpIpv4Port = sbi.Port


### PR DESCRIPTION
The `ServerIPv4` field will be used to specify the IP where the server will start.
The difference that this field makes is that now the NFs can advertise a service IP (which is different from the NodeIP) in Kubernetes.

These modifications were tested and no compatibility issues were found.

This PR comes after the discussion here: https://github.com/free5gc/free5gc/issues/49#issuecomment-640213366