### PR TITLE
Fix Plain NAS header

### DIFF
--- a/gmm/message/build.go
+++ b/gmm/message/build.go
@@ -438,7 +438,7 @@ func BuildRegistrationAccept(
 
 	registrationAccept := nasMessage.NewRegistrationAccept(0)
 	registrationAccept.ExtendedProtocolDiscriminator.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
-	registrationAccept.SpareHalfOctetAndSecurityHeaderType.SetSecurityHeaderType(nas.SecurityHeaderTypeIntegrityProtectedAndCiphered)
+	registrationAccept.SpareHalfOctetAndSecurityHeaderType.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
 	registrationAccept.SpareHalfOctetAndSecurityHeaderType.SetSpareHalfOctet(0)
 	registrationAccept.RegistrationAcceptMessageIdentity.SetMessageType(nas.MsgTypeRegistrationAccept)
 


### PR DESCRIPTION
This fixes the Plain NAS header from 0010 (=Integrity protected and ciphered) to 0000 (=Plain NAS message).

Some UE+gNB simulator does not return UERadioCapabilityInfoIndication to the RegistrationAccept with PlainNAS header:0010. After modifying Plain NAS header from 0010 to 0000 (See 93b77d7) the simulator returns UERadioCapabilityInfoIndication.
We suspect that Plain NAS header should be 0000.