### PR TITLE
Fix NSSelectionGetForPduSession error handling

### DIFF
--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -300,13 +300,15 @@ func selectSmf(ue *context.AmfUe, anType models.AccessType, pduSession *models.P
 		}
 
 		res, problemDetails, err := consumer.NSSelectionGetForPduSession(ue, *pduSession.SNssai)
-		if problemDetails != nil {
-			logger.GmmLog.Errorf("NSSelection Get Failed Problem[%+v]", problemDetails)
-		} else if err != nil {
-			logger.GmmLog.Errorf("NSSelection Get Error[%+v]", err)
-		} else {
-			nsiInformation = res.NsiInformation
+		if err != nil {
+			if problemDetails != nil {
+				logger.GmmLog.Errorf("NSSelection Get Failed Problem[%+v]", problemDetails)
+			} else {
+				logger.GmmLog.Errorf("NSSelection Get Error[%+v]", err)
+			}
+			return "", "", err
 		}
+		nsiInformation = res.NsiInformation
 	}
 
 	pduSession.NsInstance = nsiInformation.NsiId

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"free5gc/lib/fsm"
 	"free5gc/lib/nas"
@@ -300,12 +301,13 @@ func selectSmf(ue *context.AmfUe, anType models.AccessType, pduSession *models.P
 		}
 
 		res, problemDetails, err := consumer.NSSelectionGetForPduSession(ue, *pduSession.SNssai)
+		if problemDetails != nil {
+			logger.GmmLog.Errorf("NSSelection Get Failed Problem[%+v]", problemDetails)
+			err = errors.New("NSSelection Get Failed Problem")
+			return "", "", err
+		}
 		if err != nil {
-			if problemDetails != nil {
-				logger.GmmLog.Errorf("NSSelection Get Failed Problem[%+v]", problemDetails)
-			} else {
-				logger.GmmLog.Errorf("NSSelection Get Error[%+v]", err)
-			}
+			logger.GmmLog.Errorf("NSSelection Get Error[%+v]", err)
 			return "", "", err
 		}
 		nsiInformation = res.NsiInformation


### PR DESCRIPTION
This fixes error handling of the case of "nsiInformation == nil".
See https://github.com/am677/amf/commit/6f4554aed3b3b8981425357d49ae6ff9c03f69e7#diff-d18bc03b6c298e8f0f1807f19bcd8610L289-L312


before
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xaf2803]
 
goroutine 22 [running]:
free5gc/src/amf/gmm.selectSmf(0xc0000d4000, 0xdd29a3, 0xb, 0xc00071e5a0, 0xc000856a28, 0x8, 0x8, 0xc0008cbcd0, 0x198, 0x198, ...)
        /home/user/go/src/free5gc/src/amf/gmm/handler.go:312 +0x293
```
<details><summary>detail</summary><div>

```
INFO[2020-06-05T15:17:35+09:00]/src/amf/nas/nas_security/security.go:37 free5gc/src/amf/nas/nas_security.Encode() NasPdu Security: Integrity Protected And Ciphered  AMF=NAS
INFO[2020-06-05T15:17:35+09:00]/src/amf/ngap/message/send.go:340 free5gc/src/amf/ngap/message.SendInitialContextSetupRequest() [AMF] Send Initial Context Setup Request      AMF=NGAP
INFO[2020-06-05T15:17:35+09:00]/src/amf/ngap/handler.go:1615 free5gc/src/amf/ngap.HandleInitialContextSetupResponse() [AMF] Initial Context Setup Response          AMF=NGAP
INFO[2020-06-05T15:17:35+09:00]/src/amf/ngap/handler.go:3665 free5gc/src/amf/ngap.HandleUERadioCapabilityInfoIndication() [AMF] UE Radio Capability Info Indication     AMF=NGAP
INFO[2020-06-05T15:17:35+09:00]/src/amf/ngap/handler.go:181 free5gc/src/amf/ngap.HandleUplinkNasTransport() [AMF] Uplink Nas Transport                    AMF=NGAP
INFO[2020-06-05T15:17:35+09:00]/src/amf/gmm/handler.go:2105 free5gc/src/amf/gmm.HandleRegistrationComplete() [AMF] Handle Registration Complete            AMF=Gmm
INFO[2020-06-05T15:17:36+09:00]/src/amf/ngap/handler.go:181 free5gc/src/amf/ngap.HandleUplinkNasTransport() [AMF] Uplink Nas Transport                    AMF=NGAP
2020/06/05 15:17:36 map[$and:[map[nfType:NSSF] map[$or:[map[allowedNfTypes:AMF] map[allowedNfTypes:map[$exists:false]]]]]]
[GIN] 2020/06/05 - 15:17:36 | 200 |   10.720842ms |       127.0.0.1 | GET      /nnrf-disc/v1/nf-instances?requester-nf-type=AMF&target-nf-type=NSSF
INFO[2020-06-05T15:17:36+09:00] Request received - NSSelectionGet             NSSF=nsselection
panic: invalid argument to Intn
 
goroutine 21 [running]:
math/rand.(*Rand).Intn(0xc000091440, 0x0, 0x6)
        /usr/local/go/src/math/rand/rand.go:169 +0x9c
math/rand.Intn(...)
        /usr/local/go/src/math/rand/rand.go:329
free5gc/src/nssf/producer.selectNsiInformation(...)
        /home/user/go/src/free5gc/src/nssf/producer/nsselection_for_pdu_session.go:24
free5gc/src/nssf/producer.nsselectionForPduSession(0xc000282280, 0xc000326136, 0x24, 0x0, 0xc00026f700, 0x0, 0x0, 0x0, 0x0, 0xc0000bfcf8, ...)
        /home/user/go/src/free5gc/src/nssf/producer/nsselection_for_pdu_session.go:117 +0x29b
free5gc/src/nssf/producer.NSSelectionGet(0xc0000851a0, 0xc000284420)
        /home/user/go/src/free5gc/src/nssf/producer/network_slice_information_document.go:135 +0x3d7
free5gc/src/nssf/handler.Handle()
        /home/user/go/src/free5gc/src/nssf/handler/handler.go:37 +0x2e6
created by free5gc/src/nssf/service.(*NSSF).Start
        /home/user/go/src/free5gc/src/nssf/service/init.go:109 +0xd2
ERRO[2020-06-05T15:17:36+09:00]/src/amf/gmm/handler.go:306 free5gc/src/amf/gmm.selectSmf() NSSelection Get Error[NSSF No Response]       AMF=Gmm
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xaf2803]
 
goroutine 22 [running]:
free5gc/src/amf/gmm.selectSmf(0xc0000d4000, 0xdd29a3, 0xb, 0xc00071e5a0, 0xc000856a28, 0x8, 0x8, 0xc0008cbcd0, 0x198, 0x198, ...)
        /home/user/go/src/free5gc/src/amf/gmm/handler.go:312 +0x293
free5gc/src/amf/gmm.HandlePDUSessionEstablishmentRequest(0xc0000d4000, 0xdd29a3, 0xb, 0xc000856a28, 0x8, 0x8, 0x5, 0xdd4df9, 0xf, 0xc0008cbf40, ...)
        /home/user/go/src/free5gc/src/amf/gmm/handler.go:163 +0x18c
free5gc/src/amf/gmm.HandleULNASTransport(0xc0000d4000, 0xdd29a3, 0xb, 0xc0008503c0, 0xc000095b98, 0x110)
        /home/user/go/src/free5gc/src/amf/gmm/handler.go:82 +0x41d
free5gc/src/amf/gmm.register_event_3gpp(0xc0006f17e0, 0xdd2a53, 0xb, 0xc0006e7590, 0xd7aa00, 0xc000095b00)
        /home/user/go/src/free5gc/src/amf/gmm/sm.go:39 +0x72b
free5gc/src/amf/gmm.Registered_3gpp(0xc0006f17e0, 0xdd2a53, 0xb, 0xc0006e7590, 0xc0000888b0, 0xc0008cbb40)
        /home/user/go/src/free5gc/src/amf/gmm/sm.go:24 +0x49
free5gc/lib/fsm.(*FSM).SendEvent(...)
        /home/user/go/src/free5gc/lib/fsm/fsm.go:57
free5gc/src/amf/nas.Dispatch(0xc0000d4000, 0xdd29a3, 0xb, 0x2e, 0xc0008cbe80, 0xc0008cbe80, 0x0)
        /home/user/go/src/free5gc/src/amf/nas/dispatch.go:19 +0x329
free5gc/src/amf/nas.HandleNAS(0xc000095320, 0x2e, 0xc0008e3c80, 0x23, 0x30)
        /home/user/go/src/free5gc/src/amf/nas/handler.go:40 +0x10e
free5gc/src/amf/ngap.HandleUplinkNasTransport(0xc0006b9e30, 0xc0008cac60)
        /home/user/go/src/free5gc/src/amf/ngap/handler.go:240 +0x73b
free5gc/src/amf/ngap.Dispatch(0xc00081a0a0, 0x12, 0xc0007a6000, 0x51, 0x2000)
        /home/user/go/src/free5gc/src/amf/ngap/dispatcher.go:41 +0x4f2
free5gc/src/amf/handler.Handle()
        /home/user/go/src/free5gc/src/amf/handler/handler.go:36 +0x1ec
created by free5gc/src/amf/service.(*AMF).Start
        /home/user/go/src/free5gc/src/amf/service/amf_init.go:145 +0x4a9
```
</div></details>

fixed
```
ERRO[2020-06-05T15:58:11+09:00]/src/amf/gmm/handler.go:307 free5gc/src/amf/gmm.selectSmf() NSSelection Get Error[NSSF No Response]       AMF=Gmm                                                                                       
ERRO[2020-06-05T15:58:11+09:00]/src/amf/gmm/handler.go:165 free5gc/src/amf/gmm.HandlePDUSessionEstablishmentRequest() [AMF] SMF Selection for Snssai[&{Sst:1 Sd:112233}] Failed[NSSF No Response]  AMF=Gmm                             
ERRO[2020-06-05T15:58:11+09:00]/src/amf/nas/handler.go:41 free5gc/src/amf/nas.HandleNAS() Send to Nas Error: NSSF No Response           AMF=NGAP  
```
<details><summary>detail</summary><div>

```
INFO[2020-06-05T15:58:11+09:00] Request received - NSSelectionGet             NSSF=nsselection                                                                                                                                         
panic: invalid argument to Intn                                                                                                                                                                                                        
                                                                                                                                                                                                                                         
goroutine 21 [running]:                                                                                                                                                                                                                
math/rand.(*Rand).Intn(0xc000091440, 0x0, 0x6)                                                                                                                                                                                         
        /usr/local/go/src/math/rand/rand.go:169 +0x9c                                                                                                                                                                                  
math/rand.Intn(...)                                                                                                                                                                                                                    
        /usr/local/go/src/math/rand/rand.go:329                                                                                                                                                                                        
free5gc/src/nssf/producer.selectNsiInformation(...)                                                                                                                                                                                    
        /home/user/go/src/free5gc/src/nssf/producer/nsselection_for_pdu_session.go:24                                                                                                                                               
free5gc/src/nssf/producer.nsselectionForPduSession(0xc0001d2270, 0xc0001e2236, 0x24, 0x0, 0xc000366180, 0x0, 0x0, 0x0, 0x0, 0xc0003a5cf8, ...)                                                                                         
        /home/user/go/src/free5gc/src/nssf/producer/nsselection_for_pdu_session.go:117 +0x29b                                                                                                                                       
free5gc/src/nssf/producer.NSSelectionGet(0xc0003762a0, 0xc0001d0720)                                                                                                                                                                   
        /home/user/go/src/free5gc/src/nssf/producer/network_slice_information_document.go:135 +0x3d7                                                                                                                                
free5gc/src/nssf/handler.Handle()                                                                                                                                                                                                      
        /home/user/go/src/free5gc/src/nssf/handler/handler.go:37 +0x2e6                                                                                                                                                             
created by free5gc/src/nssf/service.(*NSSF).Start                                                                                                                                                                                      
        /home/user/go/src/free5gc/src/nssf/service/init.go:109 +0xd2                                                                                                                                                                
ERRO[2020-06-05T15:58:11+09:00]/src/amf/gmm/handler.go:307 free5gc/src/amf/gmm.selectSmf() NSSelection Get Error[NSSF No Response]       AMF=Gmm                                                                                       
ERRO[2020-06-05T15:58:11+09:00]/src/amf/gmm/handler.go:165 free5gc/src/amf/gmm.HandlePDUSessionEstablishmentRequest() [AMF] SMF Selection for Snssai[&{Sst:1 Sd:112233}] Failed[NSSF No Response]  AMF=Gmm                             
ERRO[2020-06-05T15:58:11+09:00]/src/amf/nas/handler.go:41 free5gc/src/amf/nas.HandleNAS() Send to Nas Error: NSSF No Response           AMF=NGAP   
```
</div></details>