### PR TITLE
AMF fails to decode id-UERadioCapability in InitialContextSetupRequest

### DIFF
--- a/ngap/message/build.go
+++ b/ngap/message/build.go
@@ -1109,7 +1109,8 @@ func BuildInitialContextSetupRequest(
 		ie.Criticality.Value = ngapType.CriticalityPresentIgnore
 		ie.Value.Present = ngapType.InitialContextSetupRequestIEsPresentUERadioCapability
 		ie.Value.UERadioCapability = new(ngapType.UERadioCapability)
-		ie.Value.UERadioCapability.Value = []byte(amfUe.UeRadioCapability)
+		uecapa, _ := hex.DecodeString(amfUe.UeRadioCapability)
+		ie.Value.UERadioCapability.Value = []byte(uecapa)
 		initialContextSetupRequestIEs.List = append(initialContextSetupRequestIEs.List, ie)
 	}
 


### PR DESCRIPTION
AMF fails to decode id-UERadioCapability in InitialContextSetupRequest due to parsing is done in string not hex.