### PR TITLE
AMF panics at HandleRegistrationComplete when Mobility/PeriodicUpdateRegistration

### DIFF
--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -1229,7 +1229,6 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ue *context.AmfUe, anType mod
 		} else {
 			ngap_message.SendDownlinkNasTransport(ue.RanUe[anType], nasPdu, nil)
 		}
-		ue.ClearRegistrationRequestData(anType)
 		return nil
 	}
 }


### PR DESCRIPTION
AMF panics at HandleRegistrationComplete when Mobility/PeriodicUpdateRegistration.
Since it refer to freed RegistrationRequestData.