### PR TITLE
AMF fails to set NAS security header in service accept

### DIFF
--- a/gmm/message/build.go
+++ b/gmm/message/build.go
@@ -176,7 +176,7 @@ func BuildServiceAccept(ue *context.AmfUe, pDUSessionStatus *[16]bool,
 
 	serviceAccept := nasMessage.NewServiceAccept(0)
 	serviceAccept.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
-	serviceAccept.SetSecurityHeaderType(nas.SecurityHeaderTypeIntegrityProtectedAndCiphered)
+	serviceAccept.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
 	serviceAccept.SetMessageType(nas.MsgTypeServiceAccept)
 	if pDUSessionStatus != nil {
 		serviceAccept.PDUSessionStatus = new(nasType.PDUSessionStatus)


### PR DESCRIPTION
The correct header must be plain in inner 5GS message