### PR TITLE
fix send to ran panic

### DIFF
--- a/ngap/message/send.go
+++ b/ngap/message/send.go
@@ -31,6 +31,16 @@ func SendToRan(ran *context.AmfRan, packet []byte) {
 		return
 	}
 
+	if ran.Conn == nil {
+		ngaplog.Error("Ran conn is nil")
+		return
+	}
+
+	if ran.Conn.RemoteAddr() == nil {
+		ngaplog.Error("Ran addr is nil")
+		return
+	}
+
 	ngaplog.Debugf("[NGAP] Send To Ran [IP: %s]", ran.Conn.RemoteAddr().String())
 
 	if n, err := ran.Conn.Write(packet); err != nil {


### PR DESCRIPTION
### 1. When amf cannot connect ran, send message to ran, will panic

### 2. amf log like this:

```
2020-12-03T08:50:04Z [INFO][AMF][Init] Terminating AMF...
2020-12-03T08:50:04Z [INFO][AMF][Consumer] [AMF] Send Deregister NFInstance
2020-12-03T08:50:05Z [INFO][AMF][Init] [AMF] Deregister from NRF successfully
2020-12-03T08:50:05Z [INFO][AMF][Init] Send AMF Status Indication to Notify RANs due to AMF terminating
2020-12-03T08:50:05Z [INFO][AMF][NGAP] [AMF] Send AMF Status Indication
2020-12-03T08:50:05Z [INFO][AMF][NGAP] [AMF] Build AMF Status Indication message
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xb7c409]

goroutine 50 [running]:
free5gc/src/amf/ngap/message.SendToRan(0xc00018b490, 0xc000328640, 0x13, 0x20)
        /root/go/src/free5gc/src/amf/ngap/message/send.go:34 +0x79
free5gc/src/amf/ngap/message.SendAMFStatusIndication(0xc00018b490, 0xc0001c41e0, 0x1, 0x1)
        /root/go/src/free5gc/src/amf/ngap/message/send.go:779 +0x1b6
free5gc/src/amf/service.(*AMF).Terminate.func1(0xe38560, 0xc000332030, 0xd96b80, 0xc00018b490, 0xc000238260)
        /root/go/src/free5gc/src/amf/service/amf_init.go:264 +0x57
sync.(*Map).Range(0x16dc640, 0xc000169f80)
        /usr/local/go/src/sync/map.go:333 +0x140
free5gc/src/amf/service.(*AMF).Terminate(0x16f9080)
        /root/go/src/free5gc/src/amf/service/amf_init.go:262 +0x1a3
free5gc/src/amf/service.(*AMF).Start.func1(0xc0000a9080, 0x16f9080)
        /root/go/src/free5gc/src/amf/service/amf_init.go:168 +0x42
created by free5gc/src/amf/service.(*AMF).Start
        /root/go/src/free5gc/src/amf/service/amf_init.go:166 +0x6d1
```

### 3. after modify, log like this:
```
2020-12-03T17:03:48+08:00 [INFO][AMF][Init] Terminating AMF...
2020-12-03T17:03:48+08:00 [INFO][AMF][Consumer] [AMF] Send Deregister NFInstance
2020-12-03T17:03:49+08:00 [INFO][AMF][Init] [AMF] Deregister from NRF successfully
2020-12-03T17:03:49+08:00 [INFO][AMF][Init] Send AMF Status Indication to Notify RANs due to AMF terminating
2020-12-03T17:03:49+08:00 [INFO][AMF][NGAP] [AMF] Send AMF Status Indication
2020-12-03T17:03:49+08:00 [INFO][AMF][NGAP] [AMF] Build AMF Status Indication message
2020-12-03T17:03:49+08:00 [ERRO][AMF][NGAP] Ran addr is nil
2020-12-03T17:03:49+08:00 [INFO][AMF][NGAP] Close SCTP server...
2020-12-03T17:03:49+08:00 [INFO][AMF][NGAP] SCTP server closed
2020-12-03T17:03:49+08:00 [INFO][AMF][Init] AMF terminated
``` 
