### PR TITLE
AMF panics when retransmission processing of Registration Accept

### DIFF
--- a/ngap/message/send.go
+++ b/ngap/message/send.go
@@ -20,6 +20,12 @@ func init() {
 }
 
 func SendToRan(ran *context.AmfRan, packet []byte) {
+	defer func() {
+		err := recover()
+		if err != nil {
+			ngaplog.Warnf("Send error, gNB may have been lost: %+v", err)
+		}
+	}()
 
 	if ran == nil {
 		ngaplog.Error("Ran is nil")


### PR DESCRIPTION
We need to call recover() when exiting SendToRan().