### PR TITLE
AMF Registration Status Update Error happens

### DIFF
--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -334,7 +334,7 @@ func (ue *AmfUe) InAllowedNssai(targetSNssai models.Snssai, anType models.Access
 
 func (ue *AmfUe) InSubscribedNssai(targetSNssai models.Snssai) bool {
 	for _, sNssai := range ue.SubscribedNssai {
-		if reflect.DeepEqual(sNssai.SubscribedSnssai, targetSNssai) {
+		if reflect.DeepEqual(*sNssai.SubscribedSnssai, targetSNssai) {
 			return true
 		}
 	}


### PR DESCRIPTION
AMF Registration Status Update Error happens when AMF receives Registration Request with Requested NSSAI.