### PR TITLE
AMF DeepEqual between pointer with entity bug.

### DIFF
--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -1447,7 +1447,7 @@ func handleRequestedNssai(ue *context.AmfUe, anType models.AccessType) error {
 						Mnc: targetAmfSetToken[1],
 					}
 
-					if !reflect.DeepEqual(guami.PlmnId, targetAmfPlmnId) {
+					if !reflect.DeepEqual(*guami.PlmnId, targetAmfPlmnId) {
 						searchTargetAmfQueryParam.TargetPlmnList =
 							optional.NewInterface(util.MarshToJsonString([]models.PlmnId{targetAmfPlmnId}))
 						searchTargetAmfQueryParam.RequesterPlmnList =


### PR DESCRIPTION
AMF uses DeepEqual between pointer with entity when comparing TargetAmfSet in  handleRequestedNssai().