### PR TITLE
HandleAuthenticationFailure() include RAND in AuthenticateRequest

### DIFF
--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -2009,6 +2009,13 @@ func HandleAuthenticationFailure(ue *context.AmfUe, anType models.AccessType,
 				Auts: hex.EncodeToString(auts[:]),
 			}
 
+			var av5gAka models.Av5gAka
+			if err := mapstructure.Decode(ue.AuthenticationCtx.Var5gAuthData, &av5gAka); err != nil {
+				logger.GmmLog.Error("Var5gAuthData Convert Type Error")
+				return err
+			}
+			resynchronizationInfo.Rand = av5gAka.Rand
+
 			response, problemDetails, err := consumer.SendUEAuthenticationAuthenticateRequest(ue, resynchronizationInfo)
 			if err != nil {
 				return err

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -2011,7 +2011,7 @@ func HandleAuthenticationFailure(ue *context.AmfUe, anType models.AccessType,
 
 			var av5gAka models.Av5gAka
 			if err := mapstructure.Decode(ue.AuthenticationCtx.Var5gAuthData, &av5gAka); err != nil {
-				logger.GmmLog.Error("Var5gAuthData Convert Type Error")
+				ue.GmmLog.Error("Var5gAuthData Convert Type Error")
 				return err
 			}
 			resynchronizationInfo.Rand = av5gAka.Rand


### PR DESCRIPTION
HandleAuthenticationFailure() include RAND in AuthenticateRequest message when handling of SynchFailure case described in TS 24.501 5.4.1.3.7 case f.