### PR TITLE
added AMFNetworkFeatureSupport5GS in amf config file

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -59,6 +59,7 @@ type AMFContext struct {
 	HttpIPv6Address                 string
 	TNLWeightFactor                 int64
 	SupportDnnLists                 []string
+	AMFNetworkFeatureSupport5GS     *AMFNetworkFeatureSupport5GS
 	AMFStatusSubscriptions          sync.Map // map[subscriptionID]models.SubscriptionData
 	NrfUri                          string
 	SecurityAlgorithm               SecurityAlgorithm
@@ -73,6 +74,11 @@ type AMFContext struct {
 	T3550Cfg factory.TimerValue
 	T3560Cfg factory.TimerValue
 	T3565Cfg factory.TimerValue
+}
+
+type AMFNetworkFeatureSupport5GS struct {
+	//TODO add further features
+	ImsVoPs bool
 }
 
 type AMFContextEventSubscription struct {

--- a/factory/config.go
+++ b/factory/config.go
@@ -34,25 +34,30 @@ const (
 )
 
 type Configuration struct {
-	AmfName                         string            `yaml:"amfName,omitempty"`
-	NgapIpList                      []string          `yaml:"ngapIpList,omitempty"`
-	Sbi                             *Sbi              `yaml:"sbi,omitempty"`
-	ServiceNameList                 []string          `yaml:"serviceNameList,omitempty"`
-	ServedGumaiList                 []models.Guami    `yaml:"servedGuamiList,omitempty"`
-	SupportTAIList                  []models.Tai      `yaml:"supportTaiList,omitempty"`
-	PlmnSupportList                 []PlmnSupportItem `yaml:"plmnSupportList,omitempty"`
-	SupportDnnList                  []string          `yaml:"supportDnnList,omitempty"`
-	NrfUri                          string            `yaml:"nrfUri,omitempty"`
-	Security                        *Security         `yaml:"security,omitempty"`
-	NetworkName                     NetworkName       `yaml:"networkName,omitempty"`
-	T3502Value                      int               `yaml:"t3502Value,omitempty"`
-	T3512Value                      int               `yaml:"t3512Value,omitempty"`
-	Non3gppDeregistrationTimerValue int               `yaml:"non3gppDeregistrationTimerValue,omitempty"`
-	T3513                           TimerValue        `yaml:"t3513"`
-	T3522                           TimerValue        `yaml:"t3522"`
-	T3550                           TimerValue        `yaml:"t3550"`
-	T3560                           TimerValue        `yaml:"t3560"`
-	T3565                           TimerValue        `yaml:"t3565"`
+	AmfName                         string                       `yaml:"amfName,omitempty"`
+	NgapIpList                      []string                     `yaml:"ngapIpList,omitempty"`
+	Sbi                             *Sbi                         `yaml:"sbi,omitempty"`
+	NetworkFeatureSupport5GS        *AMFNetworkFeatureSupport5GS `yaml:"networkFeatureSupport5GS"`
+	ServiceNameList                 []string                     `yaml:"serviceNameList,omitempty"`
+	ServedGumaiList                 []models.Guami               `yaml:"servedGuamiList,omitempty"`
+	SupportTAIList                  []models.Tai                 `yaml:"supportTaiList,omitempty"`
+	PlmnSupportList                 []PlmnSupportItem            `yaml:"plmnSupportList,omitempty"`
+	SupportDnnList                  []string                     `yaml:"supportDnnList,omitempty"`
+	NrfUri                          string                       `yaml:"nrfUri,omitempty"`
+	Security                        *Security                    `yaml:"security,omitempty"`
+	NetworkName                     NetworkName                  `yaml:"networkName,omitempty"`
+	T3502Value                      int                          `yaml:"t3502Value,omitempty"`
+	T3512Value                      int                          `yaml:"t3512Value,omitempty"`
+	Non3gppDeregistrationTimerValue int                          `yaml:"non3gppDeregistrationTimerValue,omitempty"`
+	T3513                           TimerValue                   `yaml:"t3513"`
+	T3522                           TimerValue                   `yaml:"t3522"`
+	T3550                           TimerValue                   `yaml:"t3550"`
+	T3560                           TimerValue                   `yaml:"t3560"`
+	T3565                           TimerValue                   `yaml:"t3565"`
+}
+
+type AMFNetworkFeatureSupport5GS struct {
+	ImsVoPs bool `yaml:"imsVoPs"`
 }
 
 type Sbi struct {

--- a/gmm/message/build.go
+++ b/gmm/message/build.go
@@ -531,7 +531,16 @@ func BuildRegistrationAccept(
 		registrationAccept.ConfiguredNSSAI.SetSNSSAIValue(buf)
 	}
 
-	// TODO: 5gs network feature support
+	if amfSelf.AMFNetworkFeatureSupport5GS != nil {
+		registrationAccept.NetworkFeatureSupport5GS = nasType.NewNetworkFeatureSupport5GS(nasMessage.RegistrationAcceptNetworkFeatureSupport5GSType)
+		registrationAccept.NetworkFeatureSupport5GS.SetLen(uint8(2))
+		if amfSelf.AMFNetworkFeatureSupport5GS.ImsVoPs {
+			registrationAccept.NetworkFeatureSupport5GS.SetIMSVoPS3GPP(uint8(1))
+		} else {
+			registrationAccept.NetworkFeatureSupport5GS.SetIMSVoPS3GPP(uint8(0)) //default
+		}
+		// TODO: add further 5gs network feature support fields
+	}
 
 	if pDUSessionStatus != nil {
 		registrationAccept.PDUSessionStatus = nasType.NewPDUSessionStatus(nasMessage.RegistrationAcceptPDUSessionStatusType)

--- a/util/init_context.go
+++ b/util/init_context.go
@@ -72,6 +72,9 @@ func InitAmfContext(context *context.AMFContext) {
 		context.SecurityAlgorithm.IntegrityOrder = getIntAlgOrder(security.IntegrityOrder)
 		context.SecurityAlgorithm.CipheringOrder = getEncAlgOrder(security.CipheringOrder)
 	}
+
+	context.AMFNetworkFeatureSupport5GS = getAMFNetworkFeatureSupport5GS(configuration.NetworkFeatureSupport5GS)
+
 	context.NetworkName = configuration.NetworkName
 	context.T3502Value = configuration.T3502Value
 	context.T3512Value = configuration.T3512Value
@@ -81,6 +84,15 @@ func InitAmfContext(context *context.AMFContext) {
 	context.T3550Cfg = configuration.T3550
 	context.T3560Cfg = configuration.T3560
 	context.T3565Cfg = configuration.T3565
+}
+
+func getAMFNetworkFeatureSupport5GS(featureConf *factory.AMFNetworkFeatureSupport5GS) *context.AMFNetworkFeatureSupport5GS {
+	if featureConf == nil {
+		return nil
+	}
+	nfs := &context.AMFNetworkFeatureSupport5GS{}
+	nfs.ImsVoPs = featureConf.ImsVoPs
+	return nfs
 }
 
 func getIntAlgOrder(integrityOrder []string) (intOrder []uint8) {


### PR DESCRIPTION
For the use with current existing UEs (e.g. Huawei P40) it is required to support internet and ims dnn to the UE.

For that, the amf has to indicate that IP telefony (ImsVoPs flag) is supported by the core.

This pull request merges:
* improvement of amf config file for NetworkFeatureSupport5GS 
* added additional header to registration accept NAS message which indicates the supported features of the 5G core

the need of change/improvement was already described here: [free5gc forum](https://forum.free5gc.org/t/running-free5gc-stage3-with-amarisoft-gnodeb-ue/532/6)

the syntax for the config file is as follows:

![image](https://user-images.githubusercontent.com/16240312/108880622-c3af7480-7602-11eb-8684-c56fac89bf6e.png)


if this config file entry is not set, the default value is false and no error occurs.
