### PR TITLE
Add locality in config and select SMF by locality

### DIFF
--- a/consumer/sm_context.go
+++ b/consumer/sm_context.go
@@ -84,6 +84,9 @@ func SelectSmf(
 	if ue.PlmnId.Mcc != "" {
 		param.TargetPlmnList = optional.NewInterface(util.MarshToJsonString(ue.PlmnId))
 	}
+	if amf_context.AMF_Self().Locality != "" {
+		param.PreferredLocality = optional.NewString(amf_context.AMF_Self().Locality)
+	}
 
 	ue.GmmLog.Debugf("Search SMF from NRF[%s]", nrfUri)
 

--- a/context/context.go
+++ b/context/context.go
@@ -73,6 +73,7 @@ type AMFContext struct {
 	T3550Cfg factory.TimerValue
 	T3560Cfg factory.TimerValue
 	T3565Cfg factory.TimerValue
+	Locality string
 }
 
 type AMFContextEventSubscription struct {

--- a/factory/config.go
+++ b/factory/config.go
@@ -54,6 +54,7 @@ type Configuration struct {
 	T3550                           TimerValue                `yaml:"t3550"`
 	T3560                           TimerValue                `yaml:"t3560"`
 	T3565                           TimerValue                `yaml:"t3565"`
+	Locality                        string                    `yaml:"locality,omitempty"`
 }
 
 func (c *Configuration) Get5gsNwFeatSuppEnable() bool {

--- a/util/init_context.go
+++ b/util/init_context.go
@@ -81,6 +81,7 @@ func InitAmfContext(context *context.AMFContext) {
 	context.T3550Cfg = configuration.T3550
 	context.T3560Cfg = configuration.T3560
 	context.T3565Cfg = configuration.T3565
+	context.Locality = configuration.Locality
 }
 
 func getIntAlgOrder(integrityOrder []string) (intOrder []uint8) {


### PR DESCRIPTION
This PR makes AMF to select SMF by locality.
If locality is missing, AMF selects SMF in a similar way so far.