### PR TITLE
fix FSM transition error when use EAP-AKA'

### DIFF
--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -1964,7 +1964,7 @@ func HandleAuthenticationResponse(ue *context.AmfUe, accessType models.AccessTyp
 			ue.DerivateKamf()
 			// TODO: select enc/int algorithm based on ue security capability & amf's policy,
 			// then generate KnasEnc, KnasInt
-			return GmmFSM.SendEvent(ue.State[accessType], SecurityModeSuccessEvent, fsm.ArgsType{
+			return GmmFSM.SendEvent(ue.State[accessType], AuthSuccessEvent, fsm.ArgsType{
 				ArgAmfUe:      ue,
 				ArgAccessType: accessType,
 				ArgEAPSuccess: true,


### PR DESCRIPTION
There is no transition for Authentication state when receiving the  GMMEvent SecurityModeSuccess.
And in this case, this GMMEvent is sent when UE passes EAP-AKA' authentication, so it should be AuthSuccessEvent.

