### PR TITLE
Fix: KgNB not updated during CM-IDLE to CM-CONNECTED transition

### DIFF
--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -983,6 +983,9 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ue *context.AmfUe, anType mod
 	// TODO: T3512/Non3GPP de-registration timer reassignment if need (based on operator policy)
 
 	if ue.RanUe[anType].UeContextRequest {
+		// update Kgnb/Kn3iwf
+		ue.UpdateSecurityContext(anType)
+
 		if anType == models.AccessType__3_GPP_ACCESS {
 			gmm_message.SendRegistrationAccept(ue, anType, pduSessionStatus, reactivationResult,
 				errPduSessionId, errCause, &ctxList)


### PR DESCRIPTION
The registration request's Mobility Registration Update,
Periodic Registration Update, and Emergency Registration key updates are missing.

Modify the key to be updated during the Mobility and Periodic Registration Updating.
Not Supportted Emergency Registration.

Note:3GPP TS33.501
        6.8.1.2.1 Transition from CM-IDLE to CM-CONNECTED
        6.8.1.2.2 Establishment of keys for cryptographically protected radio bearers in 3GPP access