### PR TITLE
fix(amf): AMF sends unciphered identity request

### DIFF
--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -598,7 +598,7 @@ func HandleInitialRegistration(ue *context.AmfUe, anType models.AccessType) erro
 	}
 
 	if len(ue.Pei) == 0 {
-		gmm_message.SendIdentityRequest(ue.RanUe[anType], nasMessage.MobileIdentity5GSTypeImei)
+		gmm_message.SendIdentityRequest(ue.RanUe[anType], anType, nasMessage.MobileIdentity5GSTypeImei)
 		return nil
 	}
 
@@ -746,7 +746,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ue *context.AmfUe, anType mod
 	// }
 
 	if len(ue.Pei) == 0 {
-		gmm_message.SendIdentityRequest(ue.RanUe[anType], nasMessage.MobileIdentity5GSTypeImei)
+		gmm_message.SendIdentityRequest(ue.RanUe[anType], anType, nasMessage.MobileIdentity5GSTypeImei)
 		return nil
 	}
 
@@ -1470,7 +1470,7 @@ func AuthenticationProcedure(ue *context.AmfUe, accessType models.AccessType) (b
 		}
 	} else {
 		// Request UE's SUCI by sending identity request
-		gmm_message.SendIdentityRequest(ue.RanUe[accessType], nasMessage.MobileIdentity5GSTypeSuci)
+		gmm_message.SendIdentityRequest(ue.RanUe[accessType], accessType, nasMessage.MobileIdentity5GSTypeSuci)
 		return false, nil
 	}
 
@@ -1909,7 +1909,7 @@ func HandleAuthenticationResponse(ue *context.AmfUe, accessType models.AccessTyp
 			ue.GmmLog.Errorf("HRES* Validation Failure (received: %s, expected: %s)", hResStar, av5gAka.HxresStar)
 
 			if ue.IdentityTypeUsedForRegistration == nasMessage.MobileIdentity5GSType5gGuti {
-				gmm_message.SendIdentityRequest(ue.RanUe[accessType], nasMessage.MobileIdentity5GSTypeSuci)
+				gmm_message.SendIdentityRequest(ue.RanUe[accessType], accessType, nasMessage.MobileIdentity5GSTypeSuci)
 				return nil
 			} else {
 				gmm_message.SendAuthenticationReject(ue.RanUe[accessType], "")
@@ -1942,7 +1942,7 @@ func HandleAuthenticationResponse(ue *context.AmfUe, accessType models.AccessTyp
 			})
 		case models.AuthResult_FAILURE:
 			if ue.IdentityTypeUsedForRegistration == nasMessage.MobileIdentity5GSType5gGuti {
-				gmm_message.SendIdentityRequest(ue.RanUe[accessType], nasMessage.MobileIdentity5GSTypeSuci)
+				gmm_message.SendIdentityRequest(ue.RanUe[accessType], accessType, nasMessage.MobileIdentity5GSTypeSuci)
 				return nil
 			} else {
 				gmm_message.SendAuthenticationReject(ue.RanUe[accessType], "")
@@ -1978,7 +1978,7 @@ func HandleAuthenticationResponse(ue *context.AmfUe, accessType models.AccessTyp
 		case models.AuthResult_FAILURE:
 			if ue.IdentityTypeUsedForRegistration == nasMessage.MobileIdentity5GSType5gGuti {
 				gmm_message.SendAuthenticationResult(ue.RanUe[accessType], false, response.EapPayload)
-				gmm_message.SendIdentityRequest(ue.RanUe[accessType], nasMessage.MobileIdentity5GSTypeSuci)
+				gmm_message.SendIdentityRequest(ue.RanUe[accessType], accessType, nasMessage.MobileIdentity5GSTypeSuci)
 				return nil
 			} else {
 				gmm_message.SendAuthenticationReject(ue.RanUe[accessType], response.EapPayload)

--- a/gmm/message/build.go
+++ b/gmm/message/build.go
@@ -84,10 +84,17 @@ func BuildNotification(ue *context.AmfUe, accessType models.AccessType) ([]byte,
 	return nas_security.Encode(ue, m, accessType)
 }
 
-func BuildIdentityRequest(typeOfIdentity uint8) ([]byte, error) {
+func BuildIdentityRequest(ue *context.AmfUe, accessType models.AccessType, typeOfIdentity uint8) ([]byte, error) {
 	m := nas.NewMessage()
 	m.GmmMessage = nas.NewGmmMessage()
 	m.GmmHeader.SetMessageType(nas.MsgTypeIdentityRequest)
+
+	if ue.SecurityContextAvailable {
+		m.SecurityHeader = nas.SecurityHeader{
+			ProtocolDiscriminator: nasMessage.Epd5GSMobilityManagementMessage,
+			SecurityHeaderType:    nas.SecurityHeaderTypeIntegrityProtectedAndCiphered,
+		}
+	}
 
 	identityRequest := nasMessage.NewIdentityRequest(0)
 	identityRequest.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
@@ -98,7 +105,7 @@ func BuildIdentityRequest(typeOfIdentity uint8) ([]byte, error) {
 
 	m.GmmMessage.IdentityRequest = identityRequest
 
-	return m.PlainNasEncode()
+	return nas_security.Encode(ue, m, accessType)
 }
 
 func BuildAuthenticationRequest(ue *context.AmfUe) ([]byte, error) {

--- a/gmm/message/send.go
+++ b/gmm/message/send.go
@@ -66,7 +66,7 @@ func SendNotification(ue *context.RanUe, nasMsg []byte) {
 	}
 }
 
-func SendIdentityRequest(ue *context.RanUe, typeOfIdentity uint8) {
+func SendIdentityRequest(ue *context.RanUe, accessType models.AccessType, typeOfIdentity uint8) {
 	if ue == nil {
 		logger.GmmLog.Error("SendIdentityRequest: RanUe is nil")
 		return
@@ -78,7 +78,7 @@ func SendIdentityRequest(ue *context.RanUe, typeOfIdentity uint8) {
 	amfUe := ue.AmfUe
 	amfUe.GmmLog.Info("Send Identity Request")
 
-	nasMsg, err := BuildIdentityRequest(typeOfIdentity)
+	nasMsg, err := BuildIdentityRequest(amfUe, accessType, typeOfIdentity)
 	if err != nil {
 		amfUe.GmmLog.Error(err.Error())
 		return


### PR DESCRIPTION
AMF sends unciphered identity request after NAS security procedure.

reference github issue: [#195](https://github.com/free5gc/free5gc/issues/195)