### PR TITLE
support retransmission of identity request and receicved type check

### DIFF
--- a/context/amf_ue.go
+++ b/context/amf_ue.go
@@ -65,6 +65,7 @@ type AmfUe struct {
 	DeregistrationTargetAccessType     uint8 // only used when deregistration procedure is initialized by the network
 	RegistrationAcceptForNon3GPPAccess []byte
 	RetransmissionOfInitialNASMsg      bool
+	RequestIdentityType                uint8
 	/* Used for AMF relocation */
 	TargetAmfProfile *models.NfProfile
 	TargetAmfUri     string
@@ -178,6 +179,8 @@ type AmfUe struct {
 	T3550 *Timer
 	/* T3522 (for deregistration request) */
 	T3522 *Timer
+	/* T3570 (for identity request) */
+	T3570 *Timer
 	/* Ue Context Release Cause */
 	ReleaseCause map[models.AccessType]*CauseAll
 	/* T3502 (Assigned by AMF, and used by UE to initialize registration procedure) */

--- a/context/context.go
+++ b/context/context.go
@@ -73,6 +73,7 @@ type AMFContext struct {
 	T3550Cfg factory.TimerValue
 	T3560Cfg factory.TimerValue
 	T3565Cfg factory.TimerValue
+	T3570Cfg factory.TimerValue
 	Locality string
 }
 

--- a/factory/config.go
+++ b/factory/config.go
@@ -54,6 +54,7 @@ type Configuration struct {
 	T3550                           TimerValue                `yaml:"t3550"`
 	T3560                           TimerValue                `yaml:"t3560"`
 	T3565                           TimerValue                `yaml:"t3565"`
+	T3570                           TimerValue                `yaml:"t3570"`
 	Locality                        string                    `yaml:"locality,omitempty"`
 }
 

--- a/gmm/handler.go
+++ b/gmm/handler.go
@@ -1371,6 +1371,15 @@ func HandleIdentityResponse(ue *context.AmfUe, identityResponse *nasMessage.Iden
 	ue.GmmLog.Info("Handle Identity Response")
 
 	mobileIdentityContents := identityResponse.MobileIdentity.GetMobileIdentityContents()
+	if nasConvert.GetTypeOfIdentity(mobileIdentityContents[0]) != ue.RequestIdentityType {
+		return fmt.Errorf("Received identity type doesn't match request type")
+	}
+
+	if ue.T3570 != nil {
+		ue.T3570.Stop()
+		ue.T3570 = nil // clear the timer
+	}
+
 	switch nasConvert.GetTypeOfIdentity(mobileIdentityContents[0]) { // get type of identity
 	case nasMessage.MobileIdentity5GSTypeSuci:
 		var plmnId string

--- a/util/init_context.go
+++ b/util/init_context.go
@@ -81,6 +81,7 @@ func InitAmfContext(context *context.AMFContext) {
 	context.T3550Cfg = configuration.T3550
 	context.T3560Cfg = configuration.T3560
 	context.T3565Cfg = configuration.T3565
+	context.T3570Cfg = configuration.T3570
 	context.Locality = configuration.Locality
 }
 


### PR DESCRIPTION
This PR modify thing below in current identification procedure:
- Support retransmission of identity request with timer T3570.
- Check the received identity type is equal to the one in request message.