### PR TITLE
Refine nas_security

### DIFF
--- a/internal/ngap/handler.go
+++ b/internal/ngap/handler.go
@@ -114,7 +114,7 @@ func handleUplinkNASTransportMain(ran *context.AmfRan,
 		ranUe.UpdateLocation(userLocationInformation)
 	}
 
-	nas.HandleNAS(ranUe, ngapType.ProcedureCodeUplinkNASTransport, nASPDU.Value)
+	nas.HandleNAS(ranUe, ngapType.ProcedureCodeUplinkNASTransport, nASPDU.Value, false)
 }
 
 func handleNGResetMain(ran *context.AmfRan,
@@ -500,7 +500,7 @@ func handleInitialUEMessageMain(ran *context.AmfRan,
 		ran.Log.Errorf("libngap Encoder Error: %+v", err)
 	}
 	ranUe.InitialUEMessage = pdu
-	nas.HandleNAS(ranUe, ngapType.ProcedureCodeInitialUEMessage, nASPDU.Value)
+	nas.HandleNAS(ranUe, ngapType.ProcedureCodeInitialUEMessage, nASPDU.Value, true)
 }
 
 func handlePDUSessionResourceSetupResponseMain(ran *context.AmfRan,
@@ -1576,7 +1576,7 @@ func handleNASNonDeliveryIndicationMain(ran *context.AmfRan,
 	}
 
 	if nASPDU != nil {
-		nas.HandleNAS(ranUe, ngapType.ProcedureCodeNASNonDeliveryIndication, nASPDU.Value)
+		nas.HandleNAS(ranUe, ngapType.ProcedureCodeNASNonDeliveryIndication, nASPDU.Value, false)
 	}
 }
 

--- a/internal/sbi/producer/callback.go
+++ b/internal/sbi/producer/callback.go
@@ -292,7 +292,7 @@ func N1MessageNotifyProcedure(n1MessageNotify models.N1MessageNotify) *models.Pr
 
 		gmm_common.AttachRanUeToAmfUeAndReleaseOldIfAny(amfUe, ranUe)
 
-		nas.HandleNAS(ranUe, ngapType.ProcedureCodeInitialUEMessage, n1MessageNotify.BinaryDataN1Message)
+		nas.HandleNAS(ranUe, ngapType.ProcedureCodeInitialUEMessage, n1MessageNotify.BinaryDataN1Message, true)
 	}()
 	return nil
 }


### PR DESCRIPTION
Refine functions nas_security.Encode and nas_security.Decode according to TS24.501 security specification

At decoding, if the following elements do not meet the conditions of the TS24.501, this message is treated as error.
- Message type
- NAS security header type
- Whether valid security context is existed?
- Result of integrity check
- Is message initial message?

