### PR TITLE
Fuzzing for HandleNAS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/antonfisher/nested-logrus-formatter v1.3.1
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/free5gc/aper v1.0.4
-	github.com/free5gc/nas v1.1.0
+	github.com/free5gc/nas v1.1.1
 	github.com/free5gc/ngap v1.0.6
 	github.com/free5gc/openapi v1.0.6
 	github.com/free5gc/util v1.0.3
@@ -18,6 +18,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli v1.22.5
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/free5gc/aper v1.0.4 h1:Ufbf5lzbXBOhSdUSaIdAhFMOjggsX4p6eWMrpzrrD60=
 github.com/free5gc/aper v1.0.4/go.mod h1:3K/m47BIPR2xhBkuHD1unp2LnArVtt3iTI4De0bCqpI=
-github.com/free5gc/nas v1.1.0 h1:8mIncMWG0L9BA+3oMlrYocfZ6qE+P7jZ1oe/tnXLWAs=
-github.com/free5gc/nas v1.1.0/go.mod h1:fjWwpyp7/wOyL72HTkjvIe9YTCfGyZosjITsI5sXyuU=
+github.com/free5gc/nas v1.1.1 h1:xUsqOOrb3kH38TQCzwZY7WN6WJkIerjERNjORDtnCbo=
+github.com/free5gc/nas v1.1.1/go.mod h1:fjWwpyp7/wOyL72HTkjvIe9YTCfGyZosjITsI5sXyuU=
 github.com/free5gc/ngap v1.0.6 h1:f9sKqHMNrFZVo9Kp8hAyrCXSoI8l746N5O+DFn7vKHA=
 github.com/free5gc/ngap v1.0.6/go.mod h1:TG1kwwU/EyIlJ3bxY591rdxpD5ZeYnLZTzoWjcfvrBM=
 github.com/free5gc/openapi v1.0.4/go.mod h1:KRCnnp0GeK0Bl4gnrX79cQAidKXNENf8VRdG0y9R0Fc=

--- a/internal/gmm/handler.go
+++ b/internal/gmm/handler.go
@@ -2018,6 +2018,9 @@ func HandleAuthenticationResponse(ue *context.AmfUe, accessType models.AccessTyp
 		if err := mapstructure.Decode(ue.AuthenticationCtx.Var5gAuthData, &av5gAka); err != nil {
 			return fmt.Errorf("Var5gAuthData Convert Type Error")
 		}
+		if authenticationResponse.AuthenticationResponseParameter == nil {
+			return fmt.Errorf("AuthenticationResponseParamete is nil")
+		}
 		resStar := authenticationResponse.AuthenticationResponseParameter.GetRES()
 
 		// Calculate HRES* (TS 33.501 Annex A.5)

--- a/internal/gmm/handler.go
+++ b/internal/gmm/handler.go
@@ -1439,6 +1439,9 @@ func HandleIdentityResponse(ue *context.AmfUe, identityResponse *nasMessage.Iden
 	ue.GmmLog.Info("Handle Identity Response")
 
 	mobileIdentityContents := identityResponse.MobileIdentity.GetMobileIdentityContents()
+	if len(mobileIdentityContents) < 1 {
+		return errors.New("empty Mobile Identity")
+	}
 	if nasConvert.GetTypeOfIdentity(mobileIdentityContents[0]) != ue.RequestIdentityType {
 		return fmt.Errorf("Received identity type doesn't match request type")
 	}

--- a/internal/gmm/handler.go
+++ b/internal/gmm/handler.go
@@ -2186,6 +2186,9 @@ func HandleAuthenticationFailure(ue *context.AmfUe, anType models.AccessType,
 					fsm.ArgsType{ArgAmfUe: ue, ArgAccessType: anType})
 			}
 
+			if authenticationFailure.AuthenticationFailureParameter == nil {
+				return errors.New("AuthenticationFailureParameter is nil")
+			}
 			auts := authenticationFailure.AuthenticationFailureParameter.GetAuthenticationFailureParameter()
 			resynchronizationInfo := &models.ResynchronizationInfo{
 				Auts: hex.EncodeToString(auts[:]),

--- a/internal/gmm/handler.go
+++ b/internal/gmm/handler.go
@@ -458,6 +458,9 @@ func HandleRegistrationRequest(ue *context.AmfUe, anType models.AccessType, proc
 	}
 
 	mobileIdentity5GSContents := registrationRequest.MobileIdentity5GS.GetMobileIdentity5GSContents()
+	if len(mobileIdentity5GSContents) < 1 {
+		return errors.New("broken MobileIdentity5GS")
+	}
 	ue.IdentityTypeUsedForRegistration = nasConvert.GetTypeOfIdentity(mobileIdentity5GSContents[0])
 	switch ue.IdentityTypeUsedForRegistration { // get type of identity
 	case nasMessage.MobileIdentity5GSTypeNoIdentity:

--- a/internal/gmm/handler.go
+++ b/internal/gmm/handler.go
@@ -468,6 +468,8 @@ func HandleRegistrationRequest(ue *context.AmfUe, anType models.AccessType, proc
 	case nasMessage.MobileIdentity5GSTypeSuci:
 		if suci, plmnId, err := nasConvert.SuciToStringWithError(mobileIdentity5GSContents); err != nil {
 			return fmt.Errorf("decode SUCI failed: %w", err)
+		} else if plmnId == "" {
+			return errors.New("empty plmnId")
 		} else {
 			ue.Suci = suci
 			ue.PlmnId = util.PlmnIdStringToModels(plmnId)
@@ -1450,6 +1452,8 @@ func HandleIdentityResponse(ue *context.AmfUe, identityResponse *nasMessage.Iden
 	case nasMessage.MobileIdentity5GSTypeSuci:
 		if suci, plmnId, err := nasConvert.SuciToStringWithError(mobileIdentityContents); err != nil {
 			return fmt.Errorf("decode SUCI failed: %w", err)
+		} else if plmnId == "" {
+			return errors.New("empty plmnId")
 		} else {
 			ue.Suci = suci
 			ue.PlmnId = util.PlmnIdStringToModels(plmnId)

--- a/internal/gmm/message/build.go
+++ b/internal/gmm/message/build.go
@@ -3,6 +3,7 @@ package message
 import (
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
 
 	"github.com/mitchellh/mapstructure"
 
@@ -500,7 +501,10 @@ func BuildRegistrationAccept(
 	// TODO: set smsAllowed value of RegistrationResult5GS if need
 
 	if ue.Guti != "" {
-		gutiNas := nasConvert.GutiToNas(ue.Guti)
+		gutiNas, err := nasConvert.GutiToNasWithError(ue.Guti)
+		if err != nil {
+			return nil, fmt.Errorf("encode GUTI failed: %w", err)
+		}
 		registrationAccept.GUTI5G = &gutiNas
 		registrationAccept.GUTI5G.SetIei(nasMessage.RegistrationAcceptGUTI5GType)
 	}
@@ -720,7 +724,10 @@ func BuildConfigurationUpdateCommand(ue *context.AmfUe, anType models.AccessType
 	}
 
 	if ue.Guti != "" {
-		gutiNas := nasConvert.GutiToNas(ue.Guti)
+		gutiNas, err := nasConvert.GutiToNasWithError(ue.Guti)
+		if err != nil {
+			return nil, fmt.Errorf("encode GUTI failed: %w", err)
+		}
 		configurationUpdateCommand.GUTI5G = &gutiNas
 		configurationUpdateCommand.GUTI5G.SetIei(nasMessage.ConfigurationUpdateCommandGUTI5GType)
 	}

--- a/internal/nas/fuzz_test.go
+++ b/internal/nas/fuzz_test.go
@@ -1,0 +1,105 @@
+package nas_test
+
+import (
+	"testing"
+
+	amf_context "github.com/free5gc/amf/internal/context"
+	"github.com/free5gc/amf/internal/logger"
+	amf_nas "github.com/free5gc/amf/internal/nas"
+	"github.com/free5gc/nas"
+	"github.com/free5gc/nas/nasMessage"
+	"github.com/free5gc/nas/nasType"
+	"github.com/free5gc/ngap/ngapType"
+	"github.com/free5gc/openapi/models"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzHandleNAS(f *testing.F) {
+	amfSelf := amf_context.AMF_Self()
+	amfSelf.ServedGuamiList = []models.Guami{{
+		PlmnId: &models.PlmnId{
+			Mcc: "208",
+			Mnc: "93",
+		},
+		AmfId: "cafe00",
+	}}
+	tai := models.Tai{
+		PlmnId: &models.PlmnId{
+			Mcc: "208",
+			Mnc: "93",
+		},
+		Tac: "1",
+	}
+	amfSelf.SupportTaiLists = []models.Tai{tai}
+
+	msg := nas.NewMessage()
+	msg.GmmMessage = nas.NewGmmMessage()
+	msg.GmmMessage.GmmHeader.SetMessageType(nas.MsgTypeRegistrationRequest)
+	msg.GmmMessage.RegistrationRequest = nasMessage.NewRegistrationRequest(nas.MsgTypeRegistrationRequest)
+	reg := msg.GmmMessage.RegistrationRequest
+	reg.ExtendedProtocolDiscriminator.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
+	reg.SpareHalfOctetAndSecurityHeaderType.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
+	reg.RegistrationRequestMessageIdentity.SetMessageType(nas.MsgTypeRegistrationRequest)
+	reg.NgksiAndRegistrationType5GS.SetTSC(nasMessage.TypeOfSecurityContextFlagNative)
+	reg.NgksiAndRegistrationType5GS.SetNasKeySetIdentifiler(7)
+	reg.NgksiAndRegistrationType5GS.SetFOR(1)
+	reg.NgksiAndRegistrationType5GS.SetRegistrationType5GS(nasMessage.RegistrationType5GSInitialRegistration)
+	id := []uint8{0x01, 0x02, 0xf8, 0x39, 0xf0, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10}
+	reg.MobileIdentity5GS.SetLen(uint16(len(id)))
+	reg.MobileIdentity5GS.SetMobileIdentity5GSContents(id)
+	reg.UESecurityCapability = nasType.NewUESecurityCapability(nasMessage.RegistrationRequestUESecurityCapabilityType)
+	reg.UESecurityCapability.SetLen(2)
+	reg.UESecurityCapability.SetEA0_5G(1)
+	reg.UESecurityCapability.SetIA2_128_5G(1)
+	buf, err := msg.PlainNasEncode()
+	require.NoError(f, err)
+	f.Add(buf)
+
+	msg = nas.NewMessage()
+	msg.GmmMessage = nas.NewGmmMessage()
+	msg.GmmMessage.GmmHeader.SetMessageType(nas.MsgTypeDeregistrationRequestUEOriginatingDeregistration)
+	msg.GmmMessage.DeregistrationRequestUEOriginatingDeregistration = nasMessage.NewDeregistrationRequestUEOriginatingDeregistration(nas.MsgTypeDeregistrationRequestUEOriginatingDeregistration)
+	deReg := msg.GmmMessage.DeregistrationRequestUEOriginatingDeregistration
+	deReg.ExtendedProtocolDiscriminator.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
+	deReg.SpareHalfOctetAndSecurityHeaderType.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
+	deReg.DeregistrationRequestMessageIdentity.SetMessageType(nas.MsgTypeDeregistrationRequestUEOriginatingDeregistration)
+	deReg.NgksiAndDeregistrationType.SetTSC(nasMessage.TypeOfSecurityContextFlagNative)
+	deReg.NgksiAndDeregistrationType.SetNasKeySetIdentifiler(7)
+	deReg.NgksiAndDeregistrationType.SetSwitchOff(0)
+	deReg.NgksiAndDeregistrationType.SetAccessType(nasMessage.AccessType3GPP)
+	deReg.MobileIdentity5GS.SetLen(uint16(len(id)))
+	deReg.MobileIdentity5GS.SetMobileIdentity5GSContents(id)
+	buf, err = msg.PlainNasEncode()
+	require.NoError(f, err)
+	f.Add(buf)
+
+	msg = nas.NewMessage()
+	msg.GmmMessage = nas.NewGmmMessage()
+	msg.GmmMessage.GmmHeader.SetMessageType(nas.MsgTypeServiceRequest)
+	msg.GmmMessage.ServiceRequest = nasMessage.NewServiceRequest(nas.MsgTypeServiceRequest)
+	sr := msg.GmmMessage.ServiceRequest
+	sr.ExtendedProtocolDiscriminator.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
+	sr.SpareHalfOctetAndSecurityHeaderType.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
+	sr.ServiceRequestMessageIdentity.SetMessageType(nas.MsgTypeServiceRequest)
+	sr.ServiceTypeAndNgksi.SetTSC(nasMessage.TypeOfSecurityContextFlagNative)
+	sr.ServiceTypeAndNgksi.SetNasKeySetIdentifiler(0)
+	sr.ServiceTypeAndNgksi.SetServiceTypeValue(nasMessage.ServiceTypeSignalling)
+	sr.TMSI5GS.SetLen(7)
+	buf, err = msg.PlainNasEncode()
+	require.NoError(f, err)
+	buf = append([]uint8{
+		nasMessage.Epd5GSMobilityManagementMessage,
+		nas.SecurityHeaderTypeIntegrityProtected,
+		0, 0, 0, 0, 0},
+		buf...)
+	f.Add(buf)
+
+	f.Fuzz(func(t *testing.T, d []byte) {
+		ue := new(amf_context.RanUe)
+		ue.Ran = new(amf_context.AmfRan)
+		ue.Ran.AnType = models.AccessType__3_GPP_ACCESS
+		ue.Log = logger.NgapLog
+		ue.Tai = tai
+		amf_nas.HandleNAS(ue, ngapType.ProcedureCodeInitialUEMessage, d, true)
+	})
+}

--- a/internal/nas/fuzz_test.go
+++ b/internal/nas/fuzz_test.go
@@ -1,3 +1,6 @@
+//go:build go1.18
+// +build go1.18
+
 package nas_test
 
 import (

--- a/internal/nas/fuzz_test.go
+++ b/internal/nas/fuzz_test.go
@@ -98,8 +98,123 @@ func FuzzHandleNAS(f *testing.F) {
 		ue := new(amf_context.RanUe)
 		ue.Ran = new(amf_context.AmfRan)
 		ue.Ran.AnType = models.AccessType__3_GPP_ACCESS
+		ue.Ran.Log = logger.NgapLog
 		ue.Log = logger.NgapLog
 		ue.Tai = tai
 		amf_nas.HandleNAS(ue, ngapType.ProcedureCodeInitialUEMessage, d, true)
+	})
+}
+
+func FuzzHandleNAS2(f *testing.F) {
+	amfSelf := amf_context.AMF_Self()
+	amfSelf.ServedGuamiList = []models.Guami{{
+		PlmnId: &models.PlmnId{
+			Mcc: "208",
+			Mnc: "93",
+		},
+		AmfId: "cafe00",
+	}}
+	tai := models.Tai{
+		PlmnId: &models.PlmnId{
+			Mcc: "208",
+			Mnc: "93",
+		},
+		Tac: "1",
+	}
+	amfSelf.SupportTaiLists = []models.Tai{tai}
+
+	msg := nas.NewMessage()
+	msg.GmmMessage = nas.NewGmmMessage()
+	msg.GmmMessage.GmmHeader.SetMessageType(nas.MsgTypeRegistrationRequest)
+	msg.GmmMessage.RegistrationRequest = nasMessage.NewRegistrationRequest(nas.MsgTypeRegistrationRequest)
+	reg := msg.GmmMessage.RegistrationRequest
+	reg.ExtendedProtocolDiscriminator.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
+	reg.SpareHalfOctetAndSecurityHeaderType.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
+	reg.RegistrationRequestMessageIdentity.SetMessageType(nas.MsgTypeRegistrationRequest)
+	reg.NgksiAndRegistrationType5GS.SetTSC(nasMessage.TypeOfSecurityContextFlagNative)
+	reg.NgksiAndRegistrationType5GS.SetNasKeySetIdentifiler(7)
+	reg.NgksiAndRegistrationType5GS.SetFOR(1)
+	reg.NgksiAndRegistrationType5GS.SetRegistrationType5GS(nasMessage.RegistrationType5GSInitialRegistration)
+	id := []uint8{0x01, 0x02, 0xf8, 0x39, 0xf0, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10}
+	reg.MobileIdentity5GS.SetLen(uint16(len(id)))
+	reg.MobileIdentity5GS.SetMobileIdentity5GSContents(id)
+	reg.UESecurityCapability = nasType.NewUESecurityCapability(nasMessage.RegistrationRequestUESecurityCapabilityType)
+	reg.UESecurityCapability.SetLen(2)
+	reg.UESecurityCapability.SetEA0_5G(1)
+	reg.UESecurityCapability.SetIA2_128_5G(1)
+	regPkt, err := msg.PlainNasEncode()
+	require.NoError(f, err)
+
+	msg = nas.NewMessage()
+	msg.GmmMessage = nas.NewGmmMessage()
+	msg.GmmMessage.GmmHeader.SetMessageType(nas.MsgTypeIdentityResponse)
+	msg.GmmMessage.IdentityResponse = nasMessage.NewIdentityResponse(nas.MsgTypeIdentityResponse)
+	ir := msg.GmmMessage.IdentityResponse
+	ir.ExtendedProtocolDiscriminator.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
+	ir.SpareHalfOctetAndSecurityHeaderType.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
+	ir.IdentityResponseMessageIdentity.SetMessageType(nas.MsgTypeIdentityResponse)
+	ir.MobileIdentity.SetLen(uint16(len(id)))
+	ir.MobileIdentity.SetMobileIdentityContents(id)
+	buf, err := msg.PlainNasEncode()
+	require.NoError(f, err)
+	f.Add(buf)
+
+	msg = nas.NewMessage()
+	msg.GmmMessage = nas.NewGmmMessage()
+	msg.GmmMessage.GmmHeader.SetMessageType(nas.MsgTypeAuthenticationResponse)
+	msg.GmmMessage.AuthenticationResponse = nasMessage.NewAuthenticationResponse(nas.MsgTypeAuthenticationResponse)
+	ar := msg.GmmMessage.AuthenticationResponse
+	ar.ExtendedProtocolDiscriminator.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
+	ar.SpareHalfOctetAndSecurityHeaderType.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
+	ar.AuthenticationResponseMessageIdentity.SetMessageType(nas.MsgTypeAuthenticationResponse)
+	ar.AuthenticationResponseParameter = nasType.NewAuthenticationResponseParameter(nasMessage.AuthenticationResponseAuthenticationResponseParameterType)
+	ar.AuthenticationResponseParameter.SetLen(16)
+	buf, err = msg.PlainNasEncode()
+	require.NoError(f, err)
+	f.Add(buf)
+
+	msg = nas.NewMessage()
+	msg.GmmMessage = nas.NewGmmMessage()
+	msg.GmmMessage.GmmHeader.SetMessageType(nas.MsgTypeAuthenticationFailure)
+	msg.GmmMessage.AuthenticationFailure = nasMessage.NewAuthenticationFailure(nas.MsgTypeAuthenticationFailure)
+	af := msg.GmmMessage.AuthenticationFailure
+	af.ExtendedProtocolDiscriminator.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
+	af.SpareHalfOctetAndSecurityHeaderType.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
+	af.AuthenticationFailureMessageIdentity.SetMessageType(nas.MsgTypeAuthenticationFailure)
+	af.Cause5GMM.SetCauseValue(nasMessage.Cause5GMMSynchFailure)
+	af.AuthenticationFailureParameter = nasType.NewAuthenticationFailureParameter(nasMessage.AuthenticationFailureAuthenticationFailureParameterType)
+	af.AuthenticationFailureParameter.SetLen(14)
+	buf, err = msg.PlainNasEncode()
+	require.NoError(f, err)
+	f.Add(buf)
+
+	msg = nas.NewMessage()
+	msg.GmmMessage = nas.NewGmmMessage()
+	msg.GmmMessage.GmmHeader.SetMessageType(nas.MsgTypeStatus5GMM)
+	msg.GmmMessage.Status5GMM = nasMessage.NewStatus5GMM(nas.MsgTypeStatus5GMM)
+	st := msg.GmmMessage.Status5GMM
+	st.ExtendedProtocolDiscriminator.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
+	st.SpareHalfOctetAndSecurityHeaderType.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
+	st.STATUSMessageIdentity5GMM.SetMessageType(nas.MsgTypeStatus5GMM)
+	st.Cause5GMM.SetCauseValue(nasMessage.Cause5GMMProtocolErrorUnspecified)
+	buf, err = msg.PlainNasEncode()
+	require.NoError(f, err)
+	f.Add(buf)
+
+	f.Fuzz(func(t *testing.T, d []byte) {
+		ue := new(amf_context.RanUe)
+		ue.Ran = new(amf_context.AmfRan)
+		ue.Ran.AnType = models.AccessType__3_GPP_ACCESS
+		ue.Ran.Log = logger.NgapLog
+		ue.Log = logger.NgapLog
+		ue.Tai = tai
+		amf_nas.HandleNAS(ue, ngapType.ProcedureCodeInitialUEMessage, regPkt, true)
+		amfUe := ue.AmfUe
+		amfUe.State[models.AccessType__3_GPP_ACCESS].Set(amf_context.Authentication)
+		amfUe.RequestIdentityType = nasMessage.MobileIdentity5GSTypeSuci
+		amfUe.AuthenticationCtx = &models.UeAuthenticationCtx{
+			AuthType: models.AuthType__5_G_AKA,
+		}
+		amf_nas.HandleNAS(ue, ngapType.ProcedureCodeUplinkNASTransport, d, false)
 	})
 }

--- a/internal/nas/fuzz_test.go
+++ b/internal/nas/fuzz_test.go
@@ -3,6 +3,8 @@ package nas_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	amf_context "github.com/free5gc/amf/internal/context"
 	"github.com/free5gc/amf/internal/logger"
 	amf_nas "github.com/free5gc/amf/internal/nas"
@@ -11,7 +13,6 @@ import (
 	"github.com/free5gc/nas/nasType"
 	"github.com/free5gc/ngap/ngapType"
 	"github.com/free5gc/openapi/models"
-	"github.com/stretchr/testify/require"
 )
 
 func FuzzHandleNAS(f *testing.F) {
@@ -58,8 +59,9 @@ func FuzzHandleNAS(f *testing.F) {
 	msg = nas.NewMessage()
 	msg.GmmMessage = nas.NewGmmMessage()
 	msg.GmmMessage.GmmHeader.SetMessageType(nas.MsgTypeDeregistrationRequestUEOriginatingDeregistration)
-	msg.GmmMessage.DeregistrationRequestUEOriginatingDeregistration = nasMessage.NewDeregistrationRequestUEOriginatingDeregistration(nas.MsgTypeDeregistrationRequestUEOriginatingDeregistration)
-	deReg := msg.GmmMessage.DeregistrationRequestUEOriginatingDeregistration
+	deReg := nasMessage.NewDeregistrationRequestUEOriginatingDeregistration(
+		nas.MsgTypeDeregistrationRequestUEOriginatingDeregistration)
+	msg.GmmMessage.DeregistrationRequestUEOriginatingDeregistration = deReg
 	deReg.ExtendedProtocolDiscriminator.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
 	deReg.SpareHalfOctetAndSecurityHeaderType.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
 	deReg.DeregistrationRequestMessageIdentity.SetMessageType(nas.MsgTypeDeregistrationRequestUEOriginatingDeregistration)
@@ -90,7 +92,8 @@ func FuzzHandleNAS(f *testing.F) {
 	buf = append([]uint8{
 		nasMessage.Epd5GSMobilityManagementMessage,
 		nas.SecurityHeaderTypeIntegrityProtected,
-		0, 0, 0, 0, 0},
+		0, 0, 0, 0, 0,
+	},
 		buf...)
 	f.Add(buf)
 
@@ -167,7 +170,8 @@ func FuzzHandleNAS2(f *testing.F) {
 	ar.ExtendedProtocolDiscriminator.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSMobilityManagementMessage)
 	ar.SpareHalfOctetAndSecurityHeaderType.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
 	ar.AuthenticationResponseMessageIdentity.SetMessageType(nas.MsgTypeAuthenticationResponse)
-	ar.AuthenticationResponseParameter = nasType.NewAuthenticationResponseParameter(nasMessage.AuthenticationResponseAuthenticationResponseParameterType)
+	ar.AuthenticationResponseParameter = nasType.NewAuthenticationResponseParameter(
+		nasMessage.AuthenticationResponseAuthenticationResponseParameterType)
 	ar.AuthenticationResponseParameter.SetLen(16)
 	buf, err = msg.PlainNasEncode()
 	require.NoError(f, err)
@@ -182,7 +186,8 @@ func FuzzHandleNAS2(f *testing.F) {
 	af.SpareHalfOctetAndSecurityHeaderType.SetSecurityHeaderType(nas.SecurityHeaderTypePlainNas)
 	af.AuthenticationFailureMessageIdentity.SetMessageType(nas.MsgTypeAuthenticationFailure)
 	af.Cause5GMM.SetCauseValue(nasMessage.Cause5GMMSynchFailure)
-	af.AuthenticationFailureParameter = nasType.NewAuthenticationFailureParameter(nasMessage.AuthenticationFailureAuthenticationFailureParameterType)
+	af.AuthenticationFailureParameter = nasType.NewAuthenticationFailureParameter(
+		nasMessage.AuthenticationFailureAuthenticationFailureParameterType)
 	af.AuthenticationFailureParameter.SetLen(14)
 	buf, err = msg.PlainNasEncode()
 	require.NoError(f, err)

--- a/internal/nas/testdata/fuzz/FuzzHandleNAS/046f199c68fe1f53
+++ b/internal/nas/testdata/fuzz/FuzzHandleNAS/046f199c68fe1f53
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("~0A0\x00\x02\x190")

--- a/internal/nas/testdata/fuzz/FuzzHandleNAS/3456a554a218310c
+++ b/internal/nas/testdata/fuzz/FuzzHandleNAS/3456a554a218310c
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("~0A0\x00\x011")

--- a/internal/nas/testdata/fuzz/FuzzHandleNAS/cf35851f610160df
+++ b/internal/nas/testdata/fuzz/FuzzHandleNAS/cf35851f610160df
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("~0A")

--- a/internal/nas/testdata/fuzz/FuzzHandleNAS2/116c4732855a96fe
+++ b/internal/nas/testdata/fuzz/FuzzHandleNAS2/116c4732855a96fe
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("~0\\")

--- a/internal/nas/testdata/fuzz/FuzzHandleNAS2/93a78ca68a21fa7e
+++ b/internal/nas/testdata/fuzz/FuzzHandleNAS2/93a78ca68a21fa7e
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("~0W0")

--- a/internal/nas/testdata/fuzz/FuzzHandleNAS2/973a10096b0e3ac2
+++ b/internal/nas/testdata/fuzz/FuzzHandleNAS2/973a10096b0e3ac2
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("~0Y\x15")

--- a/internal/sbi/consumer/nf_discovery.go
+++ b/internal/sbi/consumer/nf_discovery.go
@@ -24,6 +24,9 @@ func SendSearchNFInstances(nrfUri string, targetNfType, requestNfType models.NfT
 	if res != nil && res.StatusCode == http.StatusTemporaryRedirect {
 		err = fmt.Errorf("Temporary Redirect For Non NRF Consumer")
 	}
+	if res == nil || res.Body == nil {
+		return result, err
+	}
 	defer func() {
 		if bodyCloseErr := res.Body.Close(); bodyCloseErr != nil {
 			logger.ConsumerLog.Errorf("SearchNFInstances' response body cannot close: %v", bodyCloseErr)


### PR DESCRIPTION
Add fuzzing code for HandleNAS().
Add check of mobile identity and other fields in NAS message to resolve crash issue by fuzzing of HandleNAS().
Require https://github.com/free5gc/nas/pull/19.
