### PR TITLE
All build functions use nas_security.Encode()

### DIFF
--- a/internal/gmm/message/build.go
+++ b/internal/gmm/message/build.go
@@ -110,7 +110,7 @@ func BuildIdentityRequest(ue *context.AmfUe, accessType models.AccessType, typeO
 	return nas_security.Encode(ue, m, accessType)
 }
 
-func BuildAuthenticationRequest(ue *context.AmfUe) ([]byte, error) {
+func BuildAuthenticationRequest(ue *context.AmfUe, accessType models.AccessType) ([]byte, error) {
 	m := nas.NewMessage()
 	m.GmmMessage = nas.NewGmmMessage()
 	m.GmmHeader.SetMessageType(nas.MsgTypeAuthenticationRequest)
@@ -165,7 +165,11 @@ func BuildAuthenticationRequest(ue *context.AmfUe) ([]byte, error) {
 
 	m.GmmMessage.AuthenticationRequest = authenticationRequest
 
-	return m.PlainNasEncode()
+	m.SecurityHeader = nas.SecurityHeader{
+		ProtocolDiscriminator: nasMessage.Epd5GSMobilityManagementMessage,
+		SecurityHeaderType:    nas.SecurityHeaderTypeIntegrityProtectedAndCiphered,
+	}
+	return nas_security.Encode(ue, m, accessType)
 }
 
 func BuildServiceAccept(ue *context.AmfUe, accessType models.AccessType, pDUSessionStatus *[16]bool,
@@ -209,7 +213,7 @@ func BuildServiceAccept(ue *context.AmfUe, accessType models.AccessType, pDUSess
 	return nas_security.Encode(ue, m, accessType)
 }
 
-func BuildAuthenticationReject(ue *context.AmfUe, eapMsg string) ([]byte, error) {
+func BuildAuthenticationReject(ue *context.AmfUe, accessType models.AccessType, eapMsg string) ([]byte, error) {
 	m := nas.NewMessage()
 	m.GmmMessage = nas.NewGmmMessage()
 	m.GmmHeader.SetMessageType(nas.MsgTypeAuthenticationReject)
@@ -232,10 +236,15 @@ func BuildAuthenticationReject(ue *context.AmfUe, eapMsg string) ([]byte, error)
 
 	m.GmmMessage.AuthenticationReject = authenticationReject
 
-	return m.PlainNasEncode()
+	m.SecurityHeader = nas.SecurityHeader{
+		ProtocolDiscriminator: nasMessage.Epd5GSMobilityManagementMessage,
+		SecurityHeaderType:    nas.SecurityHeaderTypeIntegrityProtectedAndCiphered,
+	}
+	return nas_security.Encode(ue, m, accessType)
 }
 
-func BuildAuthenticationResult(ue *context.AmfUe, eapSuccess bool, eapMsg string) ([]byte, error) {
+func BuildAuthenticationResult(ue *context.AmfUe, accessType models.AccessType, eapSuccess bool, eapMsg string,
+) ([]byte, error) {
 	m := nas.NewMessage()
 	m.GmmMessage = nas.NewGmmMessage()
 	m.GmmHeader.SetMessageType(nas.MsgTypeAuthenticationResult)
@@ -261,11 +270,16 @@ func BuildAuthenticationResult(ue *context.AmfUe, eapSuccess bool, eapMsg string
 
 	m.GmmMessage.AuthenticationResult = authenticationResult
 
-	return m.PlainNasEncode()
+	m.SecurityHeader = nas.SecurityHeader{
+		ProtocolDiscriminator: nasMessage.Epd5GSMobilityManagementMessage,
+		SecurityHeaderType:    nas.SecurityHeaderTypeIntegrityProtectedAndCiphered,
+	}
+	return nas_security.Encode(ue, m, accessType)
 }
 
 // T3346 Timer and EAP are not Supported
-func BuildServiceReject(pDUSessionStatus *[16]bool, cause uint8) ([]byte, error) {
+func BuildServiceReject(ue *context.AmfUe, accessType models.AccessType, pDUSessionStatus *[16]bool, cause uint8,
+) ([]byte, error) {
 	m := nas.NewMessage()
 	m.GmmMessage = nas.NewGmmMessage()
 	m.GmmHeader.SetMessageType(nas.MsgTypeServiceReject)
@@ -284,11 +298,16 @@ func BuildServiceReject(pDUSessionStatus *[16]bool, cause uint8) ([]byte, error)
 
 	m.GmmMessage.ServiceReject = serviceReject
 
-	return m.PlainNasEncode()
+	m.SecurityHeader = nas.SecurityHeader{
+		ProtocolDiscriminator: nasMessage.Epd5GSMobilityManagementMessage,
+		SecurityHeaderType:    nas.SecurityHeaderTypeIntegrityProtectedAndCiphered,
+	}
+	return nas_security.Encode(ue, m, accessType)
 }
 
 // T3346 timer are not supported
-func BuildRegistrationReject(ue *context.AmfUe, cause5GMM uint8, eapMessage string) ([]byte, error) {
+func BuildRegistrationReject(ue *context.AmfUe, accessType models.AccessType, cause5GMM uint8, eapMessage string,
+) ([]byte, error) {
 	m := nas.NewMessage()
 	m.GmmMessage = nas.NewGmmMessage()
 	m.GmmHeader.SetMessageType(nas.MsgTypeRegistrationReject)
@@ -323,7 +342,11 @@ func BuildRegistrationReject(ue *context.AmfUe, cause5GMM uint8, eapMessage stri
 
 	m.GmmMessage.RegistrationReject = registrationReject
 
-	return m.PlainNasEncode()
+	m.SecurityHeader = nas.SecurityHeader{
+		ProtocolDiscriminator: nasMessage.Epd5GSMobilityManagementMessage,
+		SecurityHeaderType:    nas.SecurityHeaderTypeIntegrityProtectedAndCiphered,
+	}
+	return nas_security.Encode(ue, m, accessType)
 }
 
 // TS 24.501 8.2.25
@@ -433,23 +456,24 @@ func BuildDeregistrationRequest(ue *context.RanUe, accessType uint8, reRegistrat
 	}
 	m.GmmMessage.DeregistrationRequestUETerminatedDeregistration = deregistrationRequest
 
-	if ue != nil && ue.AmfUe != nil {
-		m.SecurityHeader = nas.SecurityHeader{
-			ProtocolDiscriminator: nasMessage.Epd5GSMobilityManagementMessage,
-			SecurityHeaderType:    nas.SecurityHeaderTypeIntegrityProtectedAndCiphered,
-		}
-		var anType models.AccessType
-		if accessType == 0x01 {
-			anType = models.AccessType__3_GPP_ACCESS
-		} else if accessType == 0x02 {
-			anType = models.AccessType_NON_3_GPP_ACCESS
-		}
-		return nas_security.Encode(ue.AmfUe, m, anType)
+	m.SecurityHeader = nas.SecurityHeader{
+		ProtocolDiscriminator: nasMessage.Epd5GSMobilityManagementMessage,
+		SecurityHeaderType:    nas.SecurityHeaderTypeIntegrityProtectedAndCiphered,
 	}
-	return m.PlainNasEncode()
+	var anType models.AccessType
+	if accessType == 0x01 {
+		anType = models.AccessType__3_GPP_ACCESS
+	} else if accessType == 0x02 {
+		anType = models.AccessType_NON_3_GPP_ACCESS
+	}
+	if ue != nil {
+		return nas_security.Encode(ue.AmfUe, m, anType)
+	} else {
+		return nas_security.Encode(nil, m, anType)
+	}
 }
 
-func BuildDeregistrationAccept() ([]byte, error) {
+func BuildDeregistrationAccept(ue *context.AmfUe, accessType models.AccessType) ([]byte, error) {
 	m := nas.NewMessage()
 	m.GmmMessage = nas.NewGmmMessage()
 	m.GmmHeader.SetMessageType(nas.MsgTypeDeregistrationAcceptUEOriginatingDeregistration)
@@ -462,7 +486,11 @@ func BuildDeregistrationAccept() ([]byte, error) {
 
 	m.GmmMessage.DeregistrationAcceptUEOriginatingDeregistration = deregistrationAccept
 
-	return m.PlainNasEncode()
+	m.SecurityHeader = nas.SecurityHeader{
+		ProtocolDiscriminator: nasMessage.Epd5GSMobilityManagementMessage,
+		SecurityHeaderType:    nas.SecurityHeaderTypeIntegrityProtectedAndCiphered,
+	}
+	return nas_security.Encode(ue, m, accessType)
 }
 
 func BuildRegistrationAccept(
@@ -677,7 +705,7 @@ func includeConfiguredNssaiCheck(ue *context.AmfUe) bool {
 	return false
 }
 
-func BuildStatus5GMM(cause uint8) ([]byte, error) {
+func BuildStatus5GMM(ue *context.AmfUe, accessType models.AccessType, cause uint8) ([]byte, error) {
 	m := nas.NewMessage()
 	m.GmmMessage = nas.NewGmmMessage()
 	m.GmmHeader.SetMessageType(nas.MsgTypeStatus5GMM)
@@ -690,7 +718,11 @@ func BuildStatus5GMM(cause uint8) ([]byte, error) {
 
 	m.GmmMessage.Status5GMM = status5GMM
 
-	return m.PlainNasEncode()
+	m.SecurityHeader = nas.SecurityHeader{
+		ProtocolDiscriminator: nasMessage.Epd5GSMobilityManagementMessage,
+		SecurityHeaderType:    nas.SecurityHeaderTypeIntegrityProtectedAndCiphered,
+	}
+	return nas_security.Encode(ue, m, accessType)
 }
 
 func BuildConfigurationUpdateCommand(ue *context.AmfUe, anType models.AccessType,
@@ -819,5 +851,9 @@ func BuildConfigurationUpdateCommand(ue *context.AmfUe, anType models.AccessType
 
 	m.GmmMessage.ConfigurationUpdateCommand = configurationUpdateCommand
 
-	return m.PlainNasEncode()
+	m.SecurityHeader = nas.SecurityHeader{
+		ProtocolDiscriminator: nasMessage.Epd5GSMobilityManagementMessage,
+		SecurityHeaderType:    nas.SecurityHeaderTypeIntegrityProtectedAndCiphered,
+	}
+	return nas_security.Encode(ue, m, anType)
 }

--- a/internal/gmm/message/send.go
+++ b/internal/gmm/message/send.go
@@ -114,6 +114,11 @@ func SendAuthenticationRequest(ue *context.RanUe) {
 		return
 	}
 	amfUe := ue.AmfUe
+	if ue.Ran == nil {
+		logger.GmmLog.Error("SendAuthenticationRequest: Ran is nil")
+		return
+	}
+	ran := ue.Ran
 	amfUe.GmmLog.Infof("Send Authentication Request")
 
 	if amfUe.AuthenticationCtx == nil {
@@ -121,7 +126,7 @@ func SendAuthenticationRequest(ue *context.RanUe) {
 		return
 	}
 
-	nasMsg, err := BuildAuthenticationRequest(amfUe)
+	nasMsg, err := BuildAuthenticationRequest(amfUe, ran.AnType)
 	if err != nil {
 		amfUe.GmmLog.Error(err.Error())
 		return
@@ -206,9 +211,14 @@ func SendAuthenticationReject(ue *context.RanUe, eapMsg string) {
 		return
 	}
 	amfUe := ue.AmfUe
+	if ue.Ran == nil {
+		logger.GmmLog.Error("SendAuthenticationReject: Ran is nil")
+		return
+	}
+	ran := ue.Ran
 	amfUe.GmmLog.Info("Send Authentication Reject")
 
-	nasMsg, err := BuildAuthenticationReject(amfUe, eapMsg)
+	nasMsg, err := BuildAuthenticationReject(amfUe, ran.AnType, eapMsg)
 	if err != nil {
 		amfUe.GmmLog.Error(err.Error())
 		return
@@ -226,9 +236,14 @@ func SendAuthenticationResult(ue *context.RanUe, eapSuccess bool, eapMsg string)
 		return
 	}
 	amfUe := ue.AmfUe
+	if ue.Ran == nil {
+		logger.GmmLog.Error("SendAuthenticationResult: Ran is nil")
+		return
+	}
+	ran := ue.Ran
 	amfUe.GmmLog.Info("Send Authentication Result")
 
-	nasMsg, err := BuildAuthenticationResult(amfUe, eapSuccess, eapMsg)
+	nasMsg, err := BuildAuthenticationResult(amfUe, ran.AnType, eapSuccess, eapMsg)
 	if err != nil {
 		amfUe.GmmLog.Error(err.Error())
 		return
@@ -241,13 +256,18 @@ func SendServiceReject(ue *context.RanUe, pDUSessionStatus *[16]bool, cause uint
 		logger.GmmLog.Error("SendServiceReject: RanUe is nil")
 		return
 	}
+	if ue.Ran == nil {
+		logger.GmmLog.Error("SendServiceReject: Ran is nil")
+		return
+	}
+	ran := ue.Ran
 	if ue.AmfUe == nil {
 		ue.Log.Info("Send Service Reject")
 	} else {
 		ue.AmfUe.GmmLog.Info("Send Service Reject")
 	}
 
-	nasMsg, err := BuildServiceReject(pDUSessionStatus, cause)
+	nasMsg, err := BuildServiceReject(ue.AmfUe, ran.AnType, pDUSessionStatus, cause)
 	if err != nil {
 		if ue.AmfUe == nil {
 			ue.Log.Error(err.Error())
@@ -266,13 +286,18 @@ func SendRegistrationReject(ue *context.RanUe, cause5GMM uint8, eapMessage strin
 		logger.GmmLog.Error("SendRegistrationReject: RanUe is nil")
 		return
 	}
+	if ue.Ran == nil {
+		logger.GmmLog.Error("SendRegistrationReject: Ran is nil")
+		return
+	}
+	ran := ue.Ran
 	if ue.AmfUe == nil {
 		ue.Log.Info("Send Registration Reject")
 	} else {
 		ue.AmfUe.GmmLog.Info("Send Registration Reject")
 	}
 
-	nasMsg, err := BuildRegistrationReject(ue.AmfUe, cause5GMM, eapMessage)
+	nasMsg, err := BuildRegistrationReject(ue.AmfUe, ran.AnType, cause5GMM, eapMessage)
 	if err != nil {
 		if ue.AmfUe == nil {
 			ue.Log.Error(err.Error())
@@ -376,9 +401,14 @@ func SendDeregistrationAccept(ue *context.RanUe) {
 		return
 	}
 	amfUe := ue.AmfUe
+	if ue.Ran == nil {
+		logger.GmmLog.Error("SendDeregistrationAccept: Ran is nil")
+		return
+	}
+	ran := ue.Ran
 	amfUe.GmmLog.Info("Send Deregistration Accept")
 
-	nasMsg, err := BuildDeregistrationAccept()
+	nasMsg, err := BuildDeregistrationAccept(ue.AmfUe, ran.AnType)
 	if err != nil {
 		amfUe.GmmLog.Error(err.Error())
 		return
@@ -449,9 +479,14 @@ func SendStatus5GMM(ue *context.RanUe, cause uint8) {
 		return
 	}
 	amfUe := ue.AmfUe
+	if ue.Ran == nil {
+		logger.GmmLog.Error("SendStatus5GMM: Ran is nil")
+		return
+	}
+	ran := ue.Ran
 	amfUe.GmmLog.Info("Send Status 5GMM")
 
-	nasMsg, err := BuildStatus5GMM(cause)
+	nasMsg, err := BuildStatus5GMM(ue.AmfUe, ran.AnType, cause)
 	if err != nil {
 		amfUe.GmmLog.Error(err.Error())
 		return


### PR DESCRIPTION
Some NAS messages are always sent as plain messages regardless of security context is valid.
This is incorrect behavior that violates NAS specifications.
This PR fix this.
