### PR TITLE
fix: only use suci to do IdentityVerification

### DIFF
--- a/internal/context/timer.go
+++ b/internal/context/timer.go
@@ -43,11 +43,13 @@ func NewTimer(d time.Duration, maxRetryTimes int,
 		for {
 			select {
 			case <-t.done:
+				close(t.done)
 				return
 			case <-ticker.C:
 				atomic.AddInt32(&t.expireTimes, 1)
 				if t.ExpireTimes() > t.MaxRetryTimes() {
 					cancelFunc()
+					close(t.done)
 					return
 				} else {
 					expiredFunc(t.ExpireTimes())
@@ -73,5 +75,12 @@ func (t *Timer) ExpireTimes() int32 {
 // otherwise it may hang on writing to done channel
 func (t *Timer) Stop() {
 	t.done <- true
-	close(t.done)
+}
+
+func (t *Timer) Done() {
+	for {
+		if t.done == nil {
+			return
+		}
+	}
 }

--- a/internal/gmm/handler.go
+++ b/internal/gmm/handler.go
@@ -603,7 +603,7 @@ func contextTransferFromOldAmf(ue *context.AmfUe, anType models.AccessType, oldA
 }
 
 func IdentityVerification(ue *context.AmfUe) bool {
-	return ue.Supi != "" || len(ue.Suci) != 0
+	return len(ue.Suci) != 0
 }
 
 func HandleInitialRegistration(ue *context.AmfUe, anType models.AccessType) error {
@@ -1591,7 +1591,7 @@ func AuthenticationProcedure(ue *context.AmfUe, accessType models.AccessType) (b
 
 	// Check whether UE has SUCI and SUPI
 	if IdentityVerification(ue) {
-		ue.GmmLog.Debugln("UE has SUCI / SUPI")
+		ue.GmmLog.Debugln("UE has SUCI")
 		if ue.SecurityContextIsValid() {
 			ue.GmmLog.Debugln("UE has a valid security context - skip the authentication procedure")
 			return true, nil

--- a/internal/gmm/handler.go
+++ b/internal/gmm/handler.go
@@ -1596,11 +1596,11 @@ func AuthenticationProcedure(ue *context.AmfUe, accessType models.AccessType) (b
 		// Request UE's SUCI by sending identity request
 		ue.IdentityRequestSendTimes++
 		gmm_message.SendIdentityRequest(ue.RanUe[accessType], accessType, nasMessage.MobileIdentity5GSTypeSuci)
+		// blocking until timer timeout/closed
+		ue.T3570.Done()
 	}
 
 	if ue.SecurityContextIsValid() {
-		// blocking until timer timeout/closed
-		ue.T3570.Done()
 		if !IdentityVerification(ue) {
 			return false, nil
 		}


### PR DESCRIPTION
According to TS 23.502 4.2.2.2.2 step 6, AMF will send **Identity Request** to UE if SUCI is not found.
![image](https://github.com/free5gc/amf/assets/46628572/666ac7c1-191c-4e8d-b43d-f0e3df46c45b)

If no SUPI in AMF, AMF will query to AUSF in step 9a:
![image](https://github.com/free5gc/amf/assets/46628572/fca8d5a6-45ba-47e8-8515-dd067521de90)
