### PR TITLE
send reroute nas msg if SendN1MessageNotifyAtAMFReAllocation failed

### DIFF
--- a/internal/sbi/producer/callback/n1n2message.go
+++ b/internal/sbi/producer/callback/n1n2message.go
@@ -88,7 +88,8 @@ func SendN1MessageNotify(ue *amf_context.AmfUe, n1class models.N1MessageClass, n
 // TS 29.518 5.2.2.3.5.2
 func SendN1MessageNotifyAtAMFReAllocation(
 	ue *amf_context.AmfUe, n1Msg []byte, registerContext *models.RegistrationContextContainer,
-) {
+) error {
+	logger.CommLog.Infoln("Send N1 Message Notify at AMF Re-allocation")
 	configuration := Namf_Communication.NewConfiguration()
 	client := Namf_Communication.NewAPIClient(configuration)
 
@@ -122,7 +123,9 @@ func SendN1MessageNotifyAtAMFReAllocation(
 		} else if err.Error() != httpResp.Status {
 			HttpLog.Errorln(err.Error())
 		}
+		return err
 	}
+	return nil
 }
 
 func SendN2InfoNotify(ue *amf_context.AmfUe, n2class models.N2InformationClass, n1Msg, n2Msg []byte) {


### PR DESCRIPTION
The current implementation does not consider the case of  Namf_Communication_N1MessageNotify failure.
In this case, I think AMF should send a NAS reroute message to UE.
This patch has been verified by the it_test.