### PR TITLE
Fix AMF sends Registration Reject if 5GMM Capability IE was not provided by the UE

### DIFF
--- a/internal/gmm/handler.go
+++ b/internal/gmm/handler.go
@@ -638,8 +638,7 @@ func HandleInitialRegistration(ue *context.AmfUe, anType models.AccessType) erro
 	if ue.RegistrationRequest.Capability5GMM != nil {
 		ue.Capability5GMM = *ue.RegistrationRequest.Capability5GMM
 	} else {
-		gmm_message.SendRegistrationReject(ue.RanUe[anType], nasMessage.Cause5GMMProtocolErrorUnspecified, "")
-		return fmt.Errorf("Capability5GMM is nil")
+		ue.GmmLog.Warnf("Capability5GMM is nil, Not sending a Registration Reject")
 	}
 
 	storeLastVisitedRegisteredTAI(ue, ue.RegistrationRequest.LastVisitedRegisteredTAI)
@@ -797,8 +796,7 @@ func HandleMobilityAndPeriodicRegistrationUpdating(ue *context.AmfUe, anType mod
 		ue.Capability5GMM = *ue.RegistrationRequest.Capability5GMM
 	} else {
 		if ue.RegistrationType5GS != nasMessage.RegistrationType5GSPeriodicRegistrationUpdating {
-			gmm_message.SendRegistrationReject(ue.RanUe[anType], nasMessage.Cause5GMMProtocolErrorUnspecified, "")
-			return fmt.Errorf("Capability5GMM is nil")
+			ue.GmmLog.Warnf("Capability5GMM is nil, Not sending a Registration Reject")
 		}
 	}
 


### PR DESCRIPTION
Hi,

The AMF is configured to set a registration reject if 5GMM Capability IE is not included. In some cases, for example with the OAI UE, the UE does not include this IE. I suggest we change the behavior to simply print a log warning and continue the registration procedure.

Please note that in case of OAI UE, the Registration procedure is successful with this change.

Closes https://github.com/free5gc/amf/issues/130

Thanks.