### PR TITLE
fix: AMF returned 500 Internal Server Error for a Event Exposure POST API request #579

### DIFF
--- a/internal/sbi/processor/event_exposure.go
+++ b/internal/sbi/processor/event_exposure.go
@@ -62,6 +62,15 @@ func (p *Processor) CreateAMFEventSubscriptionProcedure(createEventSubscription 
 		ueEventSubscription.RemainReports = new(int32)
 		*ueEventSubscription.RemainReports = subscription.Options.MaxReports
 	}
+
+	if subscription.EventList == nil {
+		problemDetails := &models.ProblemDetails{
+			Status: http.StatusBadRequest,
+			Cause:  "SUBSCRIPTION_EMPTY",
+		}
+		return nil, problemDetails
+	}
+
 	for _, events := range *subscription.EventList {
 		immediateFlags = append(immediateFlags, events.ImmediateFlag)
 		if events.ImmediateFlag {


### PR DESCRIPTION
Fix for issue: https://github.com/free5gc/free5gc/issues/579