### PR TITLE
fix: HoldingAmfUe restore when CM-Idle

### DIFF
--- a/internal/context/amf_ran.go
+++ b/internal/context/amf_ran.go
@@ -63,7 +63,7 @@ func (ran *AmfRan) NewRanUe(ranUeNgapID int64) (*RanUe, error) {
 	ranUe.RanUeNgapId = ranUeNgapID
 	ranUe.Ran = ran
 	ranUe.Log = ran.Log
-	ranUe.FindAmfUe = nil
+	ranUe.HoldingAmfUe = nil
 	ranUe.UpdateLogFields()
 
 	if ranUeNgapID != RanUeNgapIdUnspecified {

--- a/internal/context/ran_ue.go
+++ b/internal/context/ran_ue.go
@@ -47,9 +47,9 @@ type RanUe struct {
 	LastActTime       *time.Time
 
 	/* Related Context*/
-	AmfUe     *AmfUe
-	Ran       *AmfRan
-	FindAmfUe *AmfUe
+	AmfUe        *AmfUe
+	Ran          *AmfRan
+	HoldingAmfUe *AmfUe // The AmfUe that is already exist (CM-Idle, Re-Registration)
 
 	/* Routing ID */
 	RoutingID string

--- a/internal/gmm/common/user_profile.go
+++ b/internal/gmm/common/user_profile.go
@@ -54,19 +54,19 @@ func PurgeAmfUeSubscriberData(ue *context.AmfUe) {
 	}
 }
 
-func AttachRanUeToAmfUeAndReleaseOldIfAny(ue *context.AmfUe, ranUe *context.RanUe) {
-	if oldRanUe := ue.RanUe[ranUe.Ran.AnType]; oldRanUe != nil {
+func AttachRanUeToAmfUeAndReleaseOldIfAny(amfUe *context.AmfUe, ranUe *context.RanUe) {
+	if oldRanUe := amfUe.RanUe[ranUe.Ran.AnType]; oldRanUe != nil {
 		oldRanUe.Log.Infof("Implicit Deregistration - RanUeNgapID[%d]", oldRanUe.RanUeNgapId)
 		oldRanUe.DetachAmfUe()
-		if ue.T3550 != nil {
-			ue.State[ranUe.Ran.AnType].Set(context.Registered)
+		if amfUe.T3550 != nil {
+			amfUe.State[ranUe.Ran.AnType].Set(context.Registered)
 		}
-		StopAll5GSMMTimers(ue)
+		StopAll5GSMMTimers(amfUe)
 		causeGroup := ngapType.CausePresentRadioNetwork
 		causeValue := ngapType.CauseRadioNetworkPresentReleaseDueToNgranGeneratedReason
 		ngap_message.SendUEContextReleaseCommand(oldRanUe, context.UeContextReleaseUeContext, causeGroup, causeValue)
 	}
-	ue.AttachRanUe(ranUe)
+	amfUe.AttachRanUe(ranUe)
 }
 
 func ClearHoldingRanUe(ranUe *context.RanUe) {

--- a/internal/nas/handler.go
+++ b/internal/nas/handler.go
@@ -11,8 +11,6 @@ import (
 )
 
 func HandleNAS(ranUe *amf_context.RanUe, procedureCode int64, nasPdu []byte, initialMessage bool) {
-	logger.NasLog.Error("HandleNAS")
-
 	amfSelf := amf_context.GetSelf()
 
 	if ranUe == nil {
@@ -28,13 +26,13 @@ func HandleNAS(ranUe *amf_context.RanUe, procedureCode int64, nasPdu []byte, ini
 	if ranUe.AmfUe == nil {
 		if ranUe.FindAmfUe != nil && !ranUe.FindAmfUe.CmConnect(ranUe.Ran.AnType) {
 			// models.CmState_IDLE
-			logger.NasLog.Errorln("FindAmfUe", ranUe.FindAmfUe.RanUe)
 			gmm_common.ClearHoldingRanUe(ranUe.FindAmfUe.RanUe[ranUe.Ran.AnType])
 
 			ranUe.AmfUe = ranUe.FindAmfUe
 			gmm_common.AttachRanUeToAmfUeAndReleaseOldIfAny(ranUe.AmfUe, ranUe)
 			ranUe.FindAmfUe = nil
 		} else {
+			// New AmfUe
 			ranUe.AmfUe = amfSelf.NewAmfUe("")
 			gmm_common.AttachRanUeToAmfUeAndReleaseOldIfAny(ranUe.AmfUe, ranUe)
 		}
@@ -48,8 +46,7 @@ func HandleNAS(ranUe *amf_context.RanUe, procedureCode int64, nasPdu []byte, ini
 	ranUe.AmfUe.NasPduValue = nasPdu
 	ranUe.AmfUe.MacFailed = !integrityProtected
 
-	if ranUe.AmfUe.SecurityContextIsValid() && ranUe.FindAmfUe != nil &&
-		msg.GmmHeader.GetMessageType() == nas.MsgTypeRegistrationRequest {
+	if ranUe.AmfUe.SecurityContextIsValid() && ranUe.FindAmfUe != nil {
 		gmm_common.ClearHoldingRanUe(ranUe.FindAmfUe.RanUe[ranUe.Ran.AnType])
 		ranUe.FindAmfUe = nil
 	}

--- a/internal/nas/handler.go
+++ b/internal/nas/handler.go
@@ -10,39 +10,52 @@ import (
 	"github.com/free5gc/nas"
 )
 
-func HandleNAS(ue *amf_context.RanUe, procedureCode int64, nasPdu []byte, initialMessage bool) {
+func HandleNAS(ranUe *amf_context.RanUe, procedureCode int64, nasPdu []byte, initialMessage bool) {
+	logger.NasLog.Error("HandleNAS")
+
 	amfSelf := amf_context.GetSelf()
 
-	if ue == nil {
+	if ranUe == nil {
 		logger.NasLog.Error("RanUe is nil")
 		return
 	}
 
 	if nasPdu == nil {
-		ue.Log.Error("nasPdu is nil")
+		ranUe.Log.Error("nasPdu is nil")
 		return
 	}
 
-	if ue.AmfUe == nil {
-		ue.AmfUe = amfSelf.NewAmfUe("")
-		gmm_common.AttachRanUeToAmfUeAndReleaseOldIfAny(ue.AmfUe, ue)
+	if ranUe.AmfUe == nil {
+		if ranUe.FindAmfUe != nil && !ranUe.FindAmfUe.CmConnect(ranUe.Ran.AnType) {
+			// models.CmState_IDLE
+			logger.NasLog.Errorln("FindAmfUe", ranUe.FindAmfUe.RanUe)
+			gmm_common.ClearHoldingRanUe(ranUe.FindAmfUe.RanUe[ranUe.Ran.AnType])
+
+			ranUe.AmfUe = ranUe.FindAmfUe
+			gmm_common.AttachRanUeToAmfUeAndReleaseOldIfAny(ranUe.AmfUe, ranUe)
+			ranUe.FindAmfUe = nil
+		} else {
+			ranUe.AmfUe = amfSelf.NewAmfUe("")
+			gmm_common.AttachRanUeToAmfUeAndReleaseOldIfAny(ranUe.AmfUe, ranUe)
+		}
 	}
 
-	msg, integrityProtected, err := nas_security.Decode(ue.AmfUe, ue.Ran.AnType, nasPdu, initialMessage)
+	msg, integrityProtected, err := nas_security.Decode(ranUe.AmfUe, ranUe.Ran.AnType, nasPdu, initialMessage)
 	if err != nil {
-		ue.AmfUe.NASLog.Errorln(err)
+		ranUe.AmfUe.NASLog.Errorln(err)
 		return
 	}
-	ue.AmfUe.NasPduValue = nasPdu
-	ue.AmfUe.MacFailed = !integrityProtected
+	ranUe.AmfUe.NasPduValue = nasPdu
+	ranUe.AmfUe.MacFailed = !integrityProtected
 
-	if ue.AmfUe.SecurityContextIsValid() && ue.FindAmfUe != nil {
-		gmm_common.ClearHoldingRanUe(ue.FindAmfUe.RanUe[ue.Ran.AnType])
-		ue.FindAmfUe = nil
+	if ranUe.AmfUe.SecurityContextIsValid() && ranUe.FindAmfUe != nil &&
+		msg.GmmHeader.GetMessageType() == nas.MsgTypeRegistrationRequest {
+		gmm_common.ClearHoldingRanUe(ranUe.FindAmfUe.RanUe[ranUe.Ran.AnType])
+		ranUe.FindAmfUe = nil
 	}
 
-	if errDispatch := Dispatch(ue.AmfUe, ue.Ran.AnType, procedureCode, msg); errDispatch != nil {
-		ue.AmfUe.NASLog.Errorf("Handle NAS Error: %v", errDispatch)
+	if errDispatch := Dispatch(ranUe.AmfUe, ranUe.Ran.AnType, procedureCode, msg); errDispatch != nil {
+		ranUe.AmfUe.NASLog.Errorf("Handle NAS Error: %v", errDispatch)
 	}
 }
 

--- a/internal/ngap/handler.go
+++ b/internal/ngap/handler.go
@@ -498,7 +498,7 @@ func handleInitialUEMessageMain(ran *context.AmfRan,
 		// Described in TS 23.502 4.2.2.2.2 step 4 (without UDSF deployment)
 		ranUe.Log.Infof("find AmfUe [%q:%q]", idType, id)
 		ranUe.Log.Debugf("AmfUe Attach RanUe [RanUeNgapID: %d]", ranUe.RanUeNgapId)
-		ranUe.FindAmfUe = amfUe
+		ranUe.HoldingAmfUe = amfUe
 	} else if regReqType != nasMessage.RegistrationType5GSInitialRegistration {
 		if regReqType == nasMessage.RegistrationType5GSPeriodicRegistrationUpdating ||
 			regReqType == nasMessage.RegistrationType5GSMobilityRegistrationUpdating {


### PR DESCRIPTION
## Description 
This PR fixes the issue that if the UE is in CM-Idle state, the UE initiating ServiceRequest will require authentication again. 


## Others
- Related PR #136 
  - Rename `FindAmfUE` to `HoldingAmfUe` 