### PR TITLE
fix: use authctxId to authentication 

### DIFF
--- a/internal/sbi/consumer/ausf_service.go
+++ b/internal/sbi/consumer/ausf_service.go
@@ -121,7 +121,8 @@ func (s *nausfService) SendAuth5gAkaConfirmRequest(ue *amf_context.AmfUe, resSta
 	if err != nil {
 		return nil, nil, err
 	}
-	// splituri = ["","nausf-auth","ue-authentications","{authctxId}","5g-aka-confirmation"]
+	// confirmUri.RequestURI() = "/nausf-auth/v1/ue-authentications/{authctxId}/5g-aka-confirmation"
+	// splituri = ["","nausf-auth","ue-authentications",{authctxId},"5g-aka-confirmation"]
 	// authctxId = {authctxId}
 	splituri := strings.Split(confirmUri.RequestURI(), "/")
 	authctxId := ""
@@ -182,7 +183,8 @@ func (s *nausfService) SendEapAuthConfirmRequest(ue *amf_context.AmfUe, eapMsg n
 		return nil, nil, err
 	}
 
-	// splituri = ["","nausf-auth","ue-authentications","{authctxId}","eap-session"]
+	// confirmUri.RequestURI() = "/nausf-auth/v1/ue-authentications/{authctxId}/eap-session"
+	// splituri = ["","nausf-auth","ue-authentications",{authctxId},"eap-session"]
 	// authctxId = {authctxId}
 	splituri := strings.Split(confirmUri.RequestURI(), "/")
 	authctxId := ""

--- a/internal/sbi/consumer/ausf_service.go
+++ b/internal/sbi/consumer/ausf_service.go
@@ -121,6 +121,8 @@ func (s *nausfService) SendAuth5gAkaConfirmRequest(ue *amf_context.AmfUe, resSta
 	if err != nil {
 		return nil, nil, err
 	}
+	// splituri = ["","nausf-auth","ue-authentications","{authctxId}","5g-aka-confirmation"]
+	// authctxId = {authctxId}
 	splituri := strings.Split(confirmUri.RequestURI(), "/")
 	authctxId := ""
 	if len(splituri) > 4 {
@@ -180,6 +182,8 @@ func (s *nausfService) SendEapAuthConfirmRequest(ue *amf_context.AmfUe, eapMsg n
 		return nil, nil, err
 	}
 
+	// splituri = ["","nausf-auth","ue-authentications","{authctxId}","eap-session"]
+	// authctxId = {authctxId}
 	splituri := strings.Split(confirmUri.RequestURI(), "/")
 	authctxId := ""
 	if len(splituri) > 4 {

--- a/internal/sbi/consumer/ausf_service.go
+++ b/internal/sbi/consumer/ausf_service.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strconv"
 	"sync"
 
@@ -119,9 +120,12 @@ func (s *nausfService) SendAuth5gAkaConfirmRequest(ue *amf_context.AmfUe, resSta
 	if err != nil {
 		return nil, nil, err
 	}
+	re := regexp.MustCompile("/ue-authentications/.*/")
+	match := re.FindStringSubmatch(ue.AuthenticationCtx.Links["5g-aka"].Href)
+	authctxId := match[0][20 : len(match[0])-1]
 
 	confirmResult, httpResponse, err := client.DefaultApi.UeAuthenticationsAuthCtxId5gAkaConfirmationPut(
-		ctx, ue.Suci, confirmData)
+		ctx, authctxId, confirmData)
 	defer func() {
 		if httpResponse != nil {
 			if rspCloseErr := httpResponse.Body.Close(); rspCloseErr != nil {
@@ -171,7 +175,11 @@ func (s *nausfService) SendEapAuthConfirmRequest(ue *amf_context.AmfUe, eapMsg n
 		return nil, nil, err
 	}
 
-	eapSession, httpResponse, err := client.DefaultApi.EapAuthMethod(ctx, ue.Suci, eapSessionReq)
+	re := regexp.MustCompile("/ue-authentications/.*/")
+	match := re.FindStringSubmatch(ue.AuthenticationCtx.Links["eap-session"].Href)
+	authctxId := match[0][20 : len(match[0])-1]
+
+	eapSession, httpResponse, err := client.DefaultApi.EapAuthMethod(ctx, authctxId, eapSessionReq)
 	defer func() {
 		if httpResponse != nil {
 			if rspCloseErr := httpResponse.Body.Close(); rspCloseErr != nil {


### PR DESCRIPTION
The current AMF does not use the AuthctxId received from the AUSF during authentication but directly uses Ue.Suci.

---------------------------------------

1. 5g-aka
![image](https://github.com/user-attachments/assets/6143d23e-44e0-4241-a7df-1fe5f8042643)
2. EAP-based authentication method 
![image](https://github.com/user-attachments/assets/a1d740cd-f449-472d-ba78-cdd007d17433)
