### PR TITLE
fix: release twice uecontext when handover

### DIFF
--- a/internal/gmm/common/user_profile.go
+++ b/internal/gmm/common/user_profile.go
@@ -69,18 +69,18 @@ func AttachRanUeToAmfUeAndReleaseOldIfAny(amfUe *context.AmfUe, ranUe *context.R
 	amfUe.AttachRanUe(ranUe)
 }
 
-func AttachRanUeToAmfUeAndReleaseOldIfHandover(amfUe *context.AmfUe, ranUe *context.RanUe) {
-	if oldRanUe := amfUe.RanUe[ranUe.Ran.AnType]; oldRanUe != nil {
-		oldRanUe.DetachAmfUe()
+func AttachRanUeToAmfUeAndReleaseOldHandover(amfUe *context.AmfUe, sourceRanUe, targetRanUe *context.RanUe) {
+	if sourceRanUe != nil {
+		sourceRanUe.DetachAmfUe()
 		if amfUe.T3550 != nil {
-			amfUe.State[ranUe.Ran.AnType].Set(context.Registered)
+			amfUe.State[targetRanUe.Ran.AnType].Set(context.Registered)
 		}
 		StopAll5GSMMTimers(amfUe)
 		causeGroup := ngapType.CausePresentNas
 		causeValue := ngapType.CauseNasPresentNormalRelease
-		ngap_message.SendUEContextReleaseCommand(oldRanUe, context.UeContextReleaseHandover, causeGroup, causeValue)
+		ngap_message.SendUEContextReleaseCommand(sourceRanUe, context.UeContextReleaseHandover, causeGroup, causeValue)
 	}
-	amfUe.AttachRanUe(ranUe)
+	amfUe.AttachRanUe(targetRanUe)
 }
 
 func ClearHoldingRanUe(ranUe *context.RanUe) {

--- a/internal/gmm/common/user_profile.go
+++ b/internal/gmm/common/user_profile.go
@@ -69,6 +69,20 @@ func AttachRanUeToAmfUeAndReleaseOldIfAny(amfUe *context.AmfUe, ranUe *context.R
 	amfUe.AttachRanUe(ranUe)
 }
 
+func AttachRanUeToAmfUeAndReleaseOldIfHandover(amfUe *context.AmfUe, ranUe *context.RanUe) {
+	if oldRanUe := amfUe.RanUe[ranUe.Ran.AnType]; oldRanUe != nil {
+		oldRanUe.DetachAmfUe()
+		if amfUe.T3550 != nil {
+			amfUe.State[ranUe.Ran.AnType].Set(context.Registered)
+		}
+		StopAll5GSMMTimers(amfUe)
+		causeGroup := ngapType.CausePresentNas
+		causeValue := ngapType.CauseNasPresentNormalRelease
+		ngap_message.SendUEContextReleaseCommand(oldRanUe, context.UeContextReleaseHandover, causeGroup, causeValue)
+	}
+	amfUe.AttachRanUe(ranUe)
+}
+
 func ClearHoldingRanUe(ranUe *context.RanUe) {
 	if ranUe != nil {
 		ranUe.DetachAmfUe()

--- a/internal/gmm/common/user_profile.go
+++ b/internal/gmm/common/user_profile.go
@@ -78,8 +78,8 @@ func AttachRanUeToAmfUeAndReleaseOldHandover(amfUe *context.AmfUe, sourceRanUe, 
 			amfUe.State[targetRanUe.Ran.AnType].Set(context.Registered)
 		}
 		StopAll5GSMMTimers(amfUe)
-		causeGroup := ngapType.CausePresentNas
-		causeValue := ngapType.CauseNasPresentNormalRelease
+		causeGroup := ngapType.CausePresentRadioNetwork
+		causeValue := ngapType.CauseRadioNetworkPresentSuccessfulHandover
 		ngap_message.SendUEContextReleaseCommand(sourceRanUe, context.UeContextReleaseHandover, causeGroup, causeValue)
 	} else {
 		// This function will be call only by N2 Handover, so we can assume sourceRanUe will not be nil

--- a/internal/gmm/common/user_profile.go
+++ b/internal/gmm/common/user_profile.go
@@ -70,6 +70,8 @@ func AttachRanUeToAmfUeAndReleaseOldIfAny(amfUe *context.AmfUe, ranUe *context.R
 }
 
 func AttachRanUeToAmfUeAndReleaseOldHandover(amfUe *context.AmfUe, sourceRanUe, targetRanUe *context.RanUe) {
+	logger.GmmLog.Debugln("In AttachRanUeToAmfUeAndReleaseOldHandover")
+
 	if sourceRanUe != nil {
 		sourceRanUe.DetachAmfUe()
 		if amfUe.T3550 != nil {
@@ -79,6 +81,9 @@ func AttachRanUeToAmfUeAndReleaseOldHandover(amfUe *context.AmfUe, sourceRanUe, 
 		causeGroup := ngapType.CausePresentNas
 		causeValue := ngapType.CauseNasPresentNormalRelease
 		ngap_message.SendUEContextReleaseCommand(sourceRanUe, context.UeContextReleaseHandover, causeGroup, causeValue)
+	} else {
+		// This function will be call only by N2 Handover, so we can assume sourceRanUe will not be nil
+		logger.GmmLog.Errorln("AttachRanUeToAmfUeAndReleaseOldHandover() is called but sourceRanUe is nil")
 	}
 	amfUe.AttachRanUe(targetRanUe)
 }

--- a/internal/ngap/handler.go
+++ b/internal/ngap/handler.go
@@ -1211,10 +1211,8 @@ func handleHandoverNotifyMain(ran *context.AmfRan,
 				ran.Log.Errorf("Send UpdateSmContextN2HandoverComplete Error[%s]", err.Error())
 			}
 		}
-		gmm_common.AttachRanUeToAmfUeAndReleaseOldIfAny(amfUe, targetUe)
 
-		ngap_message.SendUEContextReleaseCommand(sourceUe, context.UeContextReleaseHandover, ngapType.CausePresentNas,
-			ngapType.CauseNasPresentNormalRelease)
+		gmm_common.AttachRanUeToAmfUeAndReleaseOldIfHandover(amfUe, targetUe)
 	}
 
 	// TODO: The UE initiates Mobility Registration Update procedure as described in clause 4.2.2.2.2.

--- a/internal/ngap/handler.go
+++ b/internal/ngap/handler.go
@@ -1212,7 +1212,7 @@ func handleHandoverNotifyMain(ran *context.AmfRan,
 			}
 		}
 
-		gmm_common.AttachRanUeToAmfUeAndReleaseOldIfHandover(amfUe, targetUe)
+		gmm_common.AttachRanUeToAmfUeAndReleaseOldHandover(amfUe, sourceUe, targetUe)
 	}
 
 	// TODO: The UE initiates Mobility Registration Update procedure as described in clause 4.2.2.2.2.


### PR DESCRIPTION
## Description

In free5GC v3.4.3, during an N2 handover, two "release UE context" messages are sent, causing an error during the second "handle release UE context complete."

---
Before the fix, when running ./test.sh TestN2Handover, the result is as shown in the picture.
The system sends the "release UE context" twice, but since the test function only handles it once, no error occurs.
![image](https://github.com/user-attachments/assets/5ad5534e-b863-4e3b-978f-a385ae60b023)

---
After the fix, when running ./test.sh TestN2Handover, the result is as shown in the picture, and only one "release UE context" is sent.
![image](https://github.com/user-attachments/assets/e15e71fe-a820-48ae-a681-a303b0bf6f1b)

## Related Issues
https://github.com/free5gc/free5gc/issues/604 
