### PR TITLE
fix: amf determine ue.rattype in registration

### DIFF
--- a/internal/context/amf_ran.go
+++ b/internal/context/amf_ran.go
@@ -17,6 +17,9 @@ const (
 	RanPresentGNbId   = 1
 	RanPresentNgeNbId = 2
 	RanPresentN3IwfId = 3
+	RanPresentTngfId  = 4
+	RanPresentTwifId  = 5
+	RanPresentWagfId  = 6
 )
 
 type AmfRan struct {
@@ -129,5 +132,28 @@ func (ran *AmfRan) RanID() string {
 		return fmt.Sprintf("<PlmnID: %+v, NgeNbID: %s>", *ran.RanId.PlmnId, ran.RanId.NgeNbId)
 	default:
 		return ""
+	}
+}
+
+func (ran *AmfRan) UeRatType() models.RatType {
+	// In TS 23.501 5.3.2.3
+	// For 3GPP access the AMF determines the RAT type the UE is camping on based
+	// on the Global RAN Node IDs associated with the N2 interface and
+	// additionally the Tracking Area indicated by NG-RAN
+	switch ran.RanPresent {
+	case RanPresentGNbId:
+		return models.RatType_NR
+	case RanPresentNgeNbId:
+		return models.RatType_NR
+	case RanPresentN3IwfId:
+		return models.RatType_VIRTUAL
+	case RanPresentTngfId:
+		return models.RatType_TRUSTED_N3_GA
+	case RanPresentTwifId:
+		return models.RatType_TRUSTED_N3_GA
+	case RanPresentWagfId:
+		return models.RatType_WIRELINE
+	default:
+		return models.RatType_NR
 	}
 }

--- a/internal/gmm/handler.go
+++ b/internal/gmm/handler.go
@@ -537,6 +537,11 @@ func HandleRegistrationRequest(ue *context.AmfUe, anType models.AccessType, proc
 	if ue.RanUe[anType] != nil {
 		ue.Location = ue.RanUe[anType].Location
 		ue.Tai = ue.RanUe[anType].Tai
+		if ue.RanUe[anType].Ran != nil {
+			// ue.Ratype TS 23.502 4.2.2.1
+			// The AMF determines Access Type and RAT Type as defined in clause 5.3.2.3 of TS 23.501 .
+			ue.RatType = ue.RanUe[anType].Ran.UeRatType()
+		}
 	}
 
 	// Check TAI
@@ -565,6 +570,7 @@ func HandleRegistrationRequest(ue *context.AmfUe, anType models.AccessType, proc
 			context.GetSelf().AllocateGutiToUe(ue) // refresh 5G-GUTI
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
In TS 23.502 section 4.2.2.1, it is mentioned 
```
the AMF determines the Access Type and RAT Type as defined in clause 5.3.2.3 of TS 23.501 [2]. 
```
However, the current AMF has not yet determined ue.rattype, which has caused ue.rattype to remain empty.

---
In TS 23.501 section 5.3.2.3 Registration Area management 
```
For 3GPP access the AMF determines the RAT type the UE is camping on based on the Global RAN Node IDs 
associated with the N2 interface and additionally the Tracking Area indicated by NG-RAN.
```
---
Global RAN Node ID is define in TS 38.413
![image](https://github.com/user-attachments/assets/b51fa6e3-a7fe-4bed-9ee2-9eaa75902130)




