### PR TITLE
fix: AMF-UE-NGAP-ID shall be unique within an AMF Set as specified in TS 23.501

### DIFF
--- a/internal/context/amf_ran.go
+++ b/internal/context/amf_ran.go
@@ -79,6 +79,20 @@ func (ran *AmfRan) NewRanUe(ranUeNgapID int64) (*RanUe, error) {
 	return &ranUe, nil
 }
 
+func (ran *AmfRan) NewRanUeFromAmfUeNgapID(amfUeNgapID int64) (*RanUe, error) {
+	ranUe := RanUe{}
+	self := GetSelf()
+	ranUe.AmfUeNgapId = amfUeNgapID
+	ranUe.RanUeNgapId = RanUeNgapIdUnspecified
+	ranUe.Ran = ran
+	ranUe.Log = ran.Log
+	ranUe.HoldingAmfUe = nil
+	ranUe.UpdateLogFields()
+	self.RanUePool.Store(ranUe.AmfUeNgapId, &ranUe)
+	ranUe.Log.Infof("New RanUe [RanUeNgapID:%d][AmfUeNgapID:%d]", ranUe.RanUeNgapId, ranUe.AmfUeNgapId)
+	return &ranUe, nil
+}
+
 func (ran *AmfRan) RemoveAllRanUe(removeAmfUe bool) {
 	// Using revered removal since ranUe.Remove() will also modify the slice r.RanUeList
 	ran.RanUeList.Range(func(k, v interface{}) bool {

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -477,9 +477,24 @@ func (context *AMFContext) AmfUeFindByPolicyAssociationID(polAssoId string) (*Am
 	return ue, ok
 }
 
-func (context *AMFContext) RanUeFindByAmfUeNgapID(amfUeNgapID int64) *RanUe {
+func (context *AMFContext) RanUeFindSourceByAmfUeNgapID(amfUeNgapID int64) *RanUe {
 	if value, ok := context.RanUePool.Load(amfUeNgapID); ok {
-		return value.(*RanUe)
+		r := value.(*RanUe)
+		if r.SourceUe != nil {
+			return r.SourceUe
+		}
+		return r
+	}
+	return nil
+}
+
+func (context *AMFContext) RanUeFindTargetByAmfUeNgapID(amfUeNgapID int64) *RanUe {
+	if value, ok := context.RanUePool.Load(amfUeNgapID); ok {
+		r := value.(*RanUe)
+		if r.TargetUe != nil {
+			return r.TargetUe
+		}
+		return r
 	}
 	return nil
 }

--- a/internal/ngap/handler.go
+++ b/internal/ngap/handler.go
@@ -321,7 +321,7 @@ func handleUEContextReleaseCompleteMain(ran *context.AmfRan,
 	case context.UeContextReleaseHandover:
 		ran.Log.Infof("Release UE[%s] Context : Release for Handover", amfUe.Supi)
 		// TODO: it's a workaround, need to fix it.
-		targetRanUe := context.GetSelf().RanUeFindByAmfUeNgapID(ranUe.TargetUe.AmfUeNgapId)
+		targetRanUe := context.GetSelf().RanUeFindTargetByAmfUeNgapID(ranUe.TargetUe.AmfUeNgapId)
 
 		context.DetachSourceUeTargetUe(ranUe)
 		err := ranUe.Remove()
@@ -1227,7 +1227,7 @@ func handlePathSwitchRequestMain(ran *context.AmfRan,
 	pduSessionResourceToBeSwitchedInDLList *ngapType.PDUSessionResourceToBeSwitchedDLList,
 	pduSessionResourceFailedToSetupList *ngapType.PDUSessionResourceFailedToSetupListPSReq,
 ) {
-	ranUe := context.GetSelf().RanUeFindByAmfUeNgapID(sourceAMFUENGAPID.Value)
+	ranUe := context.GetSelf().RanUeFindSourceByAmfUeNgapID(sourceAMFUENGAPID.Value)
 	if ranUe == nil {
 		ran.Log.Errorf("Cannot find UE from sourceAMfUeNgapID[%d]", sourceAMFUENGAPID.Value)
 		ngap_message.SendPathSwitchRequestFailure(ran, sourceAMFUENGAPID.Value, rANUENGAPID.Value, nil, nil)
@@ -1946,7 +1946,7 @@ func handleErrorIndicationMain(ran *context.AmfRan,
 		//  > AP ID as either the local or remote identifier.
 		// So we think that these Cause codes that represent incorrect AP ID(s) need to trigger local release.
 		if aMFUENGAPID != nil {
-			ranUe := context.GetSelf().RanUeFindByAmfUeNgapID(aMFUENGAPID.Value)
+			ranUe := context.GetSelf().RanUeFindTargetByAmfUeNgapID(aMFUENGAPID.Value)
 			if ranUe != nil && ranUe.Ran == ran {
 				removeRanUeByInvalidId(ran, ranUe, fmt.Sprintf("ErrorIndication (AmfUeNgapID: %d)", aMFUENGAPID.Value))
 			}
@@ -2142,7 +2142,7 @@ func removeRanUeByInvalidId(ran *context.AmfRan, ranUe *context.RanUe, reason st
 //	> having the erroneous AP ID as either the local or remote identifier.
 func removeRanUeByInvalidUE(ran *context.AmfRan, aMFUENGAPID *ngapType.AMFUENGAPID, rANUENGAPID *ngapType.RANUENGAPID) {
 	if aMFUENGAPID != nil {
-		ranUe := context.GetSelf().RanUeFindByAmfUeNgapID(aMFUENGAPID.Value)
+		ranUe := context.GetSelf().RanUeFindTargetByAmfUeNgapID(aMFUENGAPID.Value)
 		if ranUe != nil && ranUe.Ran == ran {
 			removeRanUeByInvalidId(ran, ranUe, fmt.Sprintf("Invalid UE ID (AmfUeNgapID: %d)", aMFUENGAPID.Value))
 		}
@@ -2175,7 +2175,7 @@ func ranUeFind(ran *context.AmfRan,
 		rANUENGAPID_string = fmt.Sprintf("%d", rANUENGAPID.Value)
 	}
 
-	ranUe = context.GetSelf().RanUeFindByAmfUeNgapID(aMFUENGAPID.Value)
+	ranUe = context.GetSelf().RanUeFindTargetByAmfUeNgapID(aMFUENGAPID.Value)
 	if ranUe == nil {
 		cause := &ngapType.Cause{
 			Present: ngapType.CausePresentRadioNetwork,

--- a/internal/ngap/message/send.go
+++ b/internal/ngap/message/send.go
@@ -519,7 +519,7 @@ func SendHandoverRequest(sourceUe *context.RanUe, targetRan *context.AmfRan, cau
 	}
 
 	var targetUe *context.RanUe
-	if targetUeTmp, err := targetRan.NewRanUe(context.RanUeNgapIdUnspecified); err != nil {
+	if targetUeTmp, err := targetRan.NewRanUeFromAmfUeNgapID(sourceUe.AmfUeNgapId); err != nil {
 		sourceUe.Log.Errorf("Create target UE error: %+v", err)
 	} else {
 		targetUe = targetUeTmp


### PR DESCRIPTION
According to TS 38.401:
> **AMF UE NGAP ID**
> An AMF UE NGAP ID shall be allocated so as to uniquely identify the UE over the NG interface within the AMF. When a NG-RAN node receives an AMF UE NGAP ID it shall store it for the duration of the UE-associated logical NG-connection for this UE.
> Once known to a NG-RAN node this ID is included in all UE associated NGAP signalling.

According to TS 23 501, section 5.9.9 (AMF UE NGAP ID):
> An AMF UE NGAP ID is an identifier used to identify the UE in AMF on N2 reference point.
> AMF allocates the AMF UE NGAP ID and send it to the 5G-AN.
> For the following N2 signalling interaction sent from 5G-AN to AMF, AMF UE NGAP ID is used to identify the UE at the AMF.
> AMF UE NGAP ID is unique per AMF set.
> AMF UE NGAP ID may be updated without AMF change, or with AMF change as specified at clause 5.21.2.2

One of the main purpose of this ID is to ensure a proper coordination of UE-specific procedures (e.g., session setup, handovers, UE context release) between the AMF and RAN.

While implementing [N2-based handover in UERANSIM](https://github.com/aligungr/UERANSIM/issues/768), @Sid-Romero discovered the AMF was incrementing the AMF UE NGAP ID on reception of the "Handover Required" message despite this ID being theoretically unique for a given UE.

This pull request is intended to fix this interoperability issue.

Important: when merging this PR, the test `TestN2Handover` also needs to be updated in https://github.com/free5gc/free5gc repository by removing the following line: https://github.com/free5gc/free5gc/blob/228ac5f7b8b0c3d160bccb3470901b3e87e756c9/test/registration_test.go#L1993