### PR TITLE
fix: nudm service name error

### DIFF
--- a/internal/sbi/consumer/udm_service.go
+++ b/internal/sbi/consumer/udm_service.go
@@ -388,7 +388,7 @@ func (s *nudmService) UeCmRegistration(
 	}
 
 	amfSelf := amf_context.GetSelf()
-	ctx, _, err := amf_context.GetSelf().GetTokenCtx(models.ServiceName_NUDM_UEAU, models.NrfNfManagementNfType_UDM)
+	ctx, _, err := amf_context.GetSelf().GetTokenCtx(models.ServiceName_NUDM_UECM, models.NrfNfManagementNfType_UDM)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR is for issue [#722](https://github.com/free5gc/free5gc/issues/722).
In `UeCmRegistration` function, the service name of the token was wrong.