### PR TITLE
fix: include UE location in N2 handover complete notification to SMF

### DIFF
--- a/internal/sbi/consumer/smf_service.go
+++ b/internal/sbi/consumer/smf_service.go
@@ -395,6 +395,7 @@ func (s *nsmfService) SendUpdateSmContextN2HandoverComplete(
 ) {
 	updateData := models.SmfPduSessionSmContextUpdateData{}
 	updateData.HoState = models.HoState_COMPLETED
+	updateData.UeLocation = &ue.Location
 	if amfid != "" {
 		updateData.ServingNfId = amfid
 		updateData.ServingNetwork = guami.PlmnId


### PR DESCRIPTION
## Summary

After N2 handover completes, AMF sends `UpdateSmContext` with `HoState=COMPLETED`
to SMF. Previously, the `ueLocation` field was not included in this request,
so SMF had no way to know the UE's post-handover location.

This fix populates `ueLocation` from `ue.Location` in
`SendUpdateSmContextN2HandoverComplete()`, allowing SMF to report the
access network change to PCF with the correct UE location.

## Motivation

Per 3GPP TS 23.502 §4.9.1.3 (N2-based Handover), after the target gNB
is ready, the AMF should report the new UE location to the SMF as part
of the handover completion step. The SMF then uses this information to
notify PCF via `SmPolicyUpdateContextData` with the `AN_CH_COR`
(Access Network Change Correlation) trigger, as defined in
TS 29.512 §5.6.3.

## Change

**File:** `internal/sbi/consumer/smf_service.go`  
**Function:** `SendUpdateSmContextN2HandoverComplete()`

```go
// Before
updateData.HoState = models.HoState_COMPLETED

// After
updateData.HoState = models.HoState_COMPLETED
updateData.UeLocation = &ue.Location
```

## Related PR
This fix works in conjunction with the following SMF change, which
consumes ueLocation to send AN_CH_COR notification to PCF:

free5gc/smf#201 

## Testing
Verified with free5gc v4.2.0 + UERANSIM + OAI rfsim two-gNB setup + vendor PCF

AMF correctly includes ueLocation in HoState=COMPLETED request to SMF
SMF receives and stores the post-handover UE location
SMF successfully notifies PCF with AN_CH_COR trigger and updated location
PCF(Vendor) returns updated policy (e.g. AMBR change), which is applied to UPF via PFCP

