### PR TITLE
fix: subscription data type inconsistency in sync.Map

### DIFF
--- a/internal/sbi/processor/subscription.go
+++ b/internal/sbi/processor/subscription.go
@@ -127,7 +127,7 @@ func (p *Processor) AMFStatusChangeSubscribeModifyProcedure(subscriptionID strin
 		currentSubscriptionData.GuamiList = append(currentSubscriptionData.GuamiList, subscriptionData.GuamiList...)
 		currentSubscriptionData.AmfStatusUri = subscriptionData.AmfStatusUri
 
-		amfSelf.AMFStatusSubscriptions.Store(subscriptionID, currentSubscriptionData)
+		amfSelf.AMFStatusSubscriptions.Store(subscriptionID, *currentSubscriptionData)
 		return currentSubscriptionData, nil
 	}
 }


### PR DESCRIPTION
This PR is for issue #[876](https://github.com/free5gc/free5gc/issues/876) #[902](https://github.com/free5gc/free5gc/issues/902).