### PR TITLE
fix(ngap/handler): don't deref a nil targetUe in handleHandoverRequestAcknowledgeMain

### DIFF
--- a/internal/ngap/handler.go
+++ b/internal/ngap/handler.go
@@ -1413,11 +1413,17 @@ func handleHandoverRequestAcknowledgeMain(ran *context.AmfRan,
 	hoFailCause := ""
 
 	defer func(hoFailCause *string) {
-		if utils.ReadStringPtr(hoFailCause) != "" {
-			business_metrics.IncrHoEventCounter(business_metrics.HANDOVER_TYPE_NGAP_VALUE,
-				utils.FailureMetric, utils.ReadStringPtr(hoFailCause),
-				targetUe.HandOverStartTime)
+		if utils.ReadStringPtr(hoFailCause) == "" {
+			return
 		}
+		// targetUe may be nil when the AMF-UE-NGAP-ID IE is missing.
+		var startTime time.Time
+		if targetUe != nil {
+			startTime = targetUe.HandOverStartTime
+		}
+		business_metrics.IncrHoEventCounter(business_metrics.HANDOVER_TYPE_NGAP_VALUE,
+			utils.FailureMetric, utils.ReadStringPtr(hoFailCause),
+			startTime)
 	}(&hoFailCause)
 
 	if criticalityDiagnostics != nil {


### PR DESCRIPTION
## Bug

`handleHandoverRequestAcknowledgeMain` installs a deferred failure-metric closure that reaches for `targetUe.HandOverStartTime` unconditionally:

```go
defer func(hoFailCause *string) {
    if utils.ReadStringPtr(hoFailCause) != "" {
        business_metrics.IncrHoEventCounter(..., targetUe.HandOverStartTime)
    }
}(&hoFailCause)

...

if targetUe == nil {
    hoFailCause = business_metrics.HANDOVER_TARGET_UE_MISSING_ERR
    ran.Log.Errorf("Target Ue is missing")
    return
}
```

`targetUe` is resolved by the caller from the `AMF-UE-NGAP-ID` IE in the `HandoverRequestAcknowledge`. A standards-valid message that simply omits that IE lands here with `targetUe == nil`, the later `if targetUe == nil` nil-check fires, and then the deferred closure tries to read `HandOverStartTime` off a nil pointer. That crashes the NGAP worker goroutine (free5gc/free5gc#1018).

Fixes free5gc/free5gc#1018.

## Change

Rework the deferred closure:

- Fast-return when `hoFailCause` is empty (previous behaviour).
- Guard the `targetUe.HandOverStartTime` read with a nil check. When `targetUe == nil`, pass a zero `time.Time` into `IncrHoEventCounter` so the metric is still emitted with the correct failure cause, just with a zero start-time instead of a panic.

The happy path is unchanged; only the failure path on malformed messages becomes non-fatal.

## Testing

- `go build ./...` passes.
- Local regression: invoked the handler with `targetUe == nil` and a non-empty `hoFailCause`. Previously the deferred closure panicked; now `IncrHoEventCounter` records the failure cause with a zero start-time and the goroutine returns normally.