### PR TITLE
Copilot/fix targetid nested fields check

### DIFF
--- a/internal/ngap/handler.go
+++ b/internal/ngap/handler.go
@@ -31,6 +31,7 @@ func handleNGSetupRequestMain(ran *context.AmfRan,
 	rANNodeName *ngapType.RANNodeName,
 	supportedTAList *ngapType.SupportedTAList,
 	pagingDRX *ngapType.PagingDRX,
+	iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList,
 ) {
 	var cause ngapType.Cause
 
@@ -95,9 +96,9 @@ func handleNGSetupRequestMain(ran *context.AmfRan,
 	}
 
 	if cause.Present == ngapType.CausePresentNothing {
-		ngap_message.SendNGSetupResponse(ran)
+		ngap_message.SendNGSetupResponse(ran, iesCriticalityDiagnostics)
 	} else {
-		ngap_message.SendNGSetupFailure(ran, cause)
+		ngap_message.SendNGSetupFailure(ran, cause, iesCriticalityDiagnostics)
 	}
 }
 

--- a/internal/ngap/handler.go
+++ b/internal/ngap/handler.go
@@ -94,15 +94,18 @@ func handleNGSetupRequestMain(ran *context.AmfRan,
 			}
 		}
 	}
-	procedureCode := ngapType.ProcedureCodeNGSetup
-	triggeringMessage := ngapType.TriggeringMessagePresentInitiatingMessage
-	procedureCriticality := ngapType.CriticalityPresentNotify
-	criticalityDiagnostics := buildCriticalityDiagnostics(
-		&procedureCode,
-		&triggeringMessage,
-		&procedureCriticality,
-		iesCriticalityDiagnostics,
-	)
+	var criticalityDiagnostics ngapType.CriticalityDiagnostics
+	if len(iesCriticalityDiagnostics.List) > 0 {
+		procedureCode := ngapType.ProcedureCodeNGSetup
+		triggeringMessage := ngapType.TriggeringMessagePresentInitiatingMessage
+		procedureCriticality := ngapType.CriticalityPresentNotify
+		criticalityDiagnostics = buildCriticalityDiagnostics(
+			&procedureCode,
+			&triggeringMessage,
+			&procedureCriticality,
+			iesCriticalityDiagnostics,
+		)
+	}
 	if cause.Present == ngapType.CausePresentNothing {
 		ngap_message.SendNGSetupResponse(ran, &criticalityDiagnostics)
 	} else {
@@ -1848,15 +1851,18 @@ func handleRANConfigurationUpdateMain(ran *context.AmfRan,
 			}
 		}
 	}
-	procedureCode := ngapType.ProcedureCodeRANConfigurationUpdate
-	triggeringMessage := ngapType.TriggeringMessagePresentInitiatingMessage
-	procedureCriticality := ngapType.CriticalityPresentNotify
-	criticalityDiagnostics := buildCriticalityDiagnostics(
-		&procedureCode,
-		&triggeringMessage,
-		&procedureCriticality,
-		iesCriticalityDiagnostics,
-	)
+	var criticalityDiagnostics ngapType.CriticalityDiagnostics
+	if len(iesCriticalityDiagnostics.List) > 0 {
+		procedureCode := ngapType.ProcedureCodeRANConfigurationUpdate
+		triggeringMessage := ngapType.TriggeringMessagePresentInitiatingMessage
+		procedureCriticality := ngapType.CriticalityPresentNotify
+		criticalityDiagnostics = buildCriticalityDiagnostics(
+			&procedureCode,
+			&triggeringMessage,
+			&procedureCriticality,
+			iesCriticalityDiagnostics,
+		)
+	}
 	if cause.Present == ngapType.CausePresentNothing {
 		ran.Log.Info("Handle RanConfigurationUpdateAcknowledge")
 		ngap_message.SendRanConfigurationUpdateAcknowledge(ran, &criticalityDiagnostics)

--- a/internal/ngap/handler.go
+++ b/internal/ngap/handler.go
@@ -94,11 +94,14 @@ func handleNGSetupRequestMain(ran *context.AmfRan,
 			}
 		}
 	}
-
+	procedureCode := ngapType.ProcedureCodeNGSetup
+	triggeringMessage := ngapType.TriggeringMessagePresentInitiatingMessage
+	procedureCriticality := ngapType.CriticalityPresentNotify
+	criticalityDiagnostics := buildCriticalityDiagnostics(&procedureCode, &triggeringMessage, &procedureCriticality, iesCriticalityDiagnostics)
 	if cause.Present == ngapType.CausePresentNothing {
-		ngap_message.SendNGSetupResponse(ran, iesCriticalityDiagnostics)
+		ngap_message.SendNGSetupResponse(ran, &criticalityDiagnostics)
 	} else {
-		ngap_message.SendNGSetupFailure(ran, cause, iesCriticalityDiagnostics)
+		ngap_message.SendNGSetupFailure(ran, cause, &criticalityDiagnostics)
 	}
 }
 
@@ -1783,6 +1786,7 @@ func handleNASNonDeliveryIndicationMain(ran *context.AmfRan,
 
 func handleRANConfigurationUpdateMain(ran *context.AmfRan,
 	supportedTAList *ngapType.SupportedTAList,
+	iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList,
 ) {
 	var cause ngapType.Cause
 
@@ -1839,13 +1843,16 @@ func handleRANConfigurationUpdateMain(ran *context.AmfRan,
 			}
 		}
 	}
-
+	procedureCode := ngapType.ProcedureCodeRANConfigurationUpdate
+	triggeringMessage := ngapType.TriggeringMessagePresentInitiatingMessage
+	procedureCriticality := ngapType.CriticalityPresentNotify
+	criticalityDiagnostics := buildCriticalityDiagnostics(&procedureCode, &triggeringMessage, &procedureCriticality, iesCriticalityDiagnostics)
 	if cause.Present == ngapType.CausePresentNothing {
 		ran.Log.Info("Handle RanConfigurationUpdateAcknowledge")
-		ngap_message.SendRanConfigurationUpdateAcknowledge(ran, nil)
+		ngap_message.SendRanConfigurationUpdateAcknowledge(ran, &criticalityDiagnostics)
 	} else {
 		ran.Log.Info("Handle RanConfigurationUpdateAcknowledgeFailure")
-		ngap_message.SendRanConfigurationUpdateFailure(ran, cause, nil)
+		ngap_message.SendRanConfigurationUpdateFailure(ran, cause, &criticalityDiagnostics)
 	}
 }
 

--- a/internal/ngap/handler.go
+++ b/internal/ngap/handler.go
@@ -97,7 +97,12 @@ func handleNGSetupRequestMain(ran *context.AmfRan,
 	procedureCode := ngapType.ProcedureCodeNGSetup
 	triggeringMessage := ngapType.TriggeringMessagePresentInitiatingMessage
 	procedureCriticality := ngapType.CriticalityPresentNotify
-	criticalityDiagnostics := buildCriticalityDiagnostics(&procedureCode, &triggeringMessage, &procedureCriticality, iesCriticalityDiagnostics)
+	criticalityDiagnostics := buildCriticalityDiagnostics(
+		&procedureCode,
+		&triggeringMessage,
+		&procedureCriticality,
+		iesCriticalityDiagnostics,
+	)
 	if cause.Present == ngapType.CausePresentNothing {
 		ngap_message.SendNGSetupResponse(ran, &criticalityDiagnostics)
 	} else {
@@ -1846,7 +1851,12 @@ func handleRANConfigurationUpdateMain(ran *context.AmfRan,
 	procedureCode := ngapType.ProcedureCodeRANConfigurationUpdate
 	triggeringMessage := ngapType.TriggeringMessagePresentInitiatingMessage
 	procedureCriticality := ngapType.CriticalityPresentNotify
-	criticalityDiagnostics := buildCriticalityDiagnostics(&procedureCode, &triggeringMessage, &procedureCriticality, iesCriticalityDiagnostics)
+	criticalityDiagnostics := buildCriticalityDiagnostics(
+		&procedureCode,
+		&triggeringMessage,
+		&procedureCriticality,
+		iesCriticalityDiagnostics,
+	)
 	if cause.Present == ngapType.CausePresentNothing {
 		ran.Log.Info("Handle RanConfigurationUpdateAcknowledge")
 		ngap_message.SendRanConfigurationUpdateAcknowledge(ran, &criticalityDiagnostics)

--- a/internal/ngap/handler_generated.go
+++ b/internal/ngap/handler_generated.go
@@ -5611,7 +5611,9 @@ func handlerNGSetupRequest(ran *context.AmfRan, initiatingMessage *ngapType.Init
 				},
 			}
 		}
-		rawSendNGSetupFailure(ran, *syntaxCause, nil, &criticalityDiagnostics)
+		if abort {
+			rawSendNGSetupFailure(ran, *syntaxCause, nil, &criticalityDiagnostics)
+		}
 	}
 
 	if abort {
@@ -5639,8 +5641,9 @@ func handlerNGSetupRequest(ran *context.AmfRan, initiatingMessage *ngapType.Init
 	//	globalRANNodeID *ngapType.GlobalRANNodeID,
 	//	rANNodeName *ngapType.RANNodeName,
 	//	supportedTAList *ngapType.SupportedTAList,
-	//	defaultPagingDRX *ngapType.PagingDRX) {
-	handleNGSetupRequestMain(ran, globalRANNodeID, rANNodeName /* may be nil */, supportedTAList, defaultPagingDRX /* may be nil */)
+	//	defaultPagingDRX *ngapType.PagingDRX,
+	//	&iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList) {
+	handleNGSetupRequestMain(ran, globalRANNodeID, rANNodeName /* may be nil */, supportedTAList, defaultPagingDRX /* may be nil */, &iesCriticalityDiagnostics /* may be nil */)
 }
 
 func handlerNGSetupResponse(ran *context.AmfRan, successfulOutcome *ngapType.SuccessfulOutcome) {

--- a/internal/ngap/handler_generated.go
+++ b/internal/ngap/handler_generated.go
@@ -5593,7 +5593,7 @@ func handlerNGSetupRequest(ran *context.AmfRan, initiatingMessage *ngapType.Init
 		abort = true
 	}
 
-	if syntaxCause != nil || len(iesCriticalityDiagnostics.List) > 0 {
+	if abort {
 		ran.Log.Trace("Has IE error")
 		procedureCode := ngapType.ProcedureCodeNGSetup
 		triggeringMessage := ngapType.TriggeringMessagePresentInitiatingMessage
@@ -5611,9 +5611,7 @@ func handlerNGSetupRequest(ran *context.AmfRan, initiatingMessage *ngapType.Init
 				},
 			}
 		}
-		if abort {
-			rawSendNGSetupFailure(ran, *syntaxCause, nil, &criticalityDiagnostics)
-		}
+		rawSendNGSetupFailure(ran, *syntaxCause, nil, &criticalityDiagnostics)
 	}
 
 	if abort {
@@ -8875,7 +8873,7 @@ func handlerRANConfigurationUpdate(ran *context.AmfRan, initiatingMessage *ngapT
 		}
 	}
 
-	if syntaxCause != nil || len(iesCriticalityDiagnostics.List) > 0 {
+	if abort {
 		ran.Log.Trace("Has IE error")
 		procedureCode := ngapType.ProcedureCodeRANConfigurationUpdate
 		triggeringMessage := ngapType.TriggeringMessagePresentInitiatingMessage
@@ -8913,8 +8911,9 @@ func handlerRANConfigurationUpdate(ran *context.AmfRan, initiatingMessage *ngapT
 	metricStatusOk = true
 
 	// func handleRANConfigurationUpdateMain(ran *context.AmfRan,
-	//	supportedTAList *ngapType.SupportedTAList) {
-	handleRANConfigurationUpdateMain(ran, supportedTAList /* may be nil */)
+	//	supportedTAList *ngapType.SupportedTAList,
+	//	&iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList) {
+	handleRANConfigurationUpdateMain(ran, supportedTAList /* may be nil */, &iesCriticalityDiagnostics /* may be nil */)
 }
 
 func handlerRANConfigurationUpdateAcknowledge(ran *context.AmfRan, successfulOutcome *ngapType.SuccessfulOutcome) {

--- a/internal/ngap/handler_generated.go
+++ b/internal/ngap/handler_generated.go
@@ -5612,9 +5612,6 @@ func handlerNGSetupRequest(ran *context.AmfRan, initiatingMessage *ngapType.Init
 			}
 		}
 		rawSendNGSetupFailure(ran, *syntaxCause, nil, &criticalityDiagnostics)
-	}
-
-	if abort {
 		return
 	}
 
@@ -8892,9 +8889,6 @@ func handlerRANConfigurationUpdate(ran *context.AmfRan, initiatingMessage *ngapT
 			}
 		}
 		rawSendRANConfigurationUpdateFailure(ran, *syntaxCause, nil, &criticalityDiagnostics)
-	}
-
-	if abort {
 		return
 	}
 

--- a/internal/ngap/message/build.go
+++ b/internal/ngap/message/build.go
@@ -80,7 +80,7 @@ func BuildPDUSessionResourceReleaseCommand(ue *context.RanUe, nasPdu []byte,
 	return ngap.Encoder(pdu)
 }
 
-func BuildNGSetupResponse() ([]byte, error) {
+func BuildNGSetupResponse(iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList) ([]byte, error) {
 	amfSelf := context.GetSelf()
 	var pdu ngapType.NGAPPDU
 	pdu.Present = ngapType.NGAPPDUPresentSuccessfulOutcome
@@ -158,11 +158,20 @@ func BuildNGSetupResponse() ([]byte, error) {
 	}
 
 	nGSetupResponseIEs.List = append(nGSetupResponseIEs.List, ie)
+	if len(iesCriticalityDiagnostics.List) > 0 {
+		ie = ngapType.NGSetupResponseIEs{}
+		ie.Id.Value = ngapType.ProtocolIEIDCriticalityDiagnostics
+		ie.Criticality.Value = ngapType.CriticalityPresentNotify
+		ie.Value.Present = ngapType.NGSetupResponseIEsPresentCriticalityDiagnostics
+		ie.Value.CriticalityDiagnostics = new(ngapType.CriticalityDiagnostics)
+		ie.Value.CriticalityDiagnostics.IEsCriticalityDiagnostics = iesCriticalityDiagnostics
+		nGSetupResponseIEs.List = append(nGSetupResponseIEs.List, ie)
+	}
 
 	return ngap.Encoder(pdu)
 }
 
-func BuildNGSetupFailure(cause ngapType.Cause) ([]byte, error) {
+func BuildNGSetupFailure(cause ngapType.Cause, iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList) ([]byte, error) {
 	var pdu ngapType.NGAPPDU
 	pdu.Present = ngapType.NGAPPDUPresentUnsuccessfulOutcome
 	pdu.UnsuccessfulOutcome = new(ngapType.UnsuccessfulOutcome)
@@ -184,6 +193,15 @@ func BuildNGSetupFailure(cause ngapType.Cause) ([]byte, error) {
 	ie.Value.Cause = &cause
 
 	nGSetupFailureIEs.List = append(nGSetupFailureIEs.List, ie)
+	if len(iesCriticalityDiagnostics.List) > 0 {
+		ie = ngapType.NGSetupFailureIEs{}
+		ie.Id.Value = ngapType.ProtocolIEIDCriticalityDiagnostics
+		ie.Criticality.Value = ngapType.CriticalityPresentNotify
+		ie.Value.Present = ngapType.NGSetupFailureIEsPresentCriticalityDiagnostics
+		ie.Value.CriticalityDiagnostics = new(ngapType.CriticalityDiagnostics)
+		ie.Value.CriticalityDiagnostics.IEsCriticalityDiagnostics = iesCriticalityDiagnostics
+		nGSetupFailureIEs.List = append(nGSetupFailureIEs.List, ie)
+	}
 
 	return ngap.Encoder(pdu)
 }

--- a/internal/ngap/message/build.go
+++ b/internal/ngap/message/build.go
@@ -80,7 +80,9 @@ func BuildPDUSessionResourceReleaseCommand(ue *context.RanUe, nasPdu []byte,
 	return ngap.Encoder(pdu)
 }
 
-func BuildNGSetupResponse(iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList) ([]byte, error) {
+func BuildNGSetupResponse(
+	iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList,
+) ([]byte, error) {
 	amfSelf := context.GetSelf()
 	var pdu ngapType.NGAPPDU
 	pdu.Present = ngapType.NGAPPDUPresentSuccessfulOutcome
@@ -171,7 +173,9 @@ func BuildNGSetupResponse(iesCriticalityDiagnostics *ngapType.CriticalityDiagnos
 	return ngap.Encoder(pdu)
 }
 
-func BuildNGSetupFailure(cause ngapType.Cause, iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList) ([]byte, error) {
+func BuildNGSetupFailure(
+	cause ngapType.Cause, iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList,
+) ([]byte, error) {
 	var pdu ngapType.NGAPPDU
 	pdu.Present = ngapType.NGAPPDUPresentUnsuccessfulOutcome
 	pdu.UnsuccessfulOutcome = new(ngapType.UnsuccessfulOutcome)

--- a/internal/ngap/message/build.go
+++ b/internal/ngap/message/build.go
@@ -81,7 +81,7 @@ func BuildPDUSessionResourceReleaseCommand(ue *context.RanUe, nasPdu []byte,
 }
 
 func BuildNGSetupResponse(
-	iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList,
+	criticalityDiagnostics *ngapType.CriticalityDiagnostics,
 ) ([]byte, error) {
 	amfSelf := context.GetSelf()
 	var pdu ngapType.NGAPPDU
@@ -160,13 +160,14 @@ func BuildNGSetupResponse(
 	}
 
 	nGSetupResponseIEs.List = append(nGSetupResponseIEs.List, ie)
-	if len(iesCriticalityDiagnostics.List) > 0 {
+	if criticalityDiagnostics != nil {
 		ie = ngapType.NGSetupResponseIEs{}
 		ie.Id.Value = ngapType.ProtocolIEIDCriticalityDiagnostics
-		ie.Criticality.Value = ngapType.CriticalityPresentNotify
+		ie.Criticality.Value = ngapType.CriticalityPresentIgnore
 		ie.Value.Present = ngapType.NGSetupResponseIEsPresentCriticalityDiagnostics
 		ie.Value.CriticalityDiagnostics = new(ngapType.CriticalityDiagnostics)
-		ie.Value.CriticalityDiagnostics.IEsCriticalityDiagnostics = iesCriticalityDiagnostics
+
+		ie.Value.CriticalityDiagnostics = criticalityDiagnostics
 		nGSetupResponseIEs.List = append(nGSetupResponseIEs.List, ie)
 	}
 
@@ -174,7 +175,7 @@ func BuildNGSetupResponse(
 }
 
 func BuildNGSetupFailure(
-	cause ngapType.Cause, iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList,
+	cause ngapType.Cause, criticalityDiagnostics *ngapType.CriticalityDiagnostics,
 ) ([]byte, error) {
 	var pdu ngapType.NGAPPDU
 	pdu.Present = ngapType.NGAPPDUPresentUnsuccessfulOutcome
@@ -197,13 +198,14 @@ func BuildNGSetupFailure(
 	ie.Value.Cause = &cause
 
 	nGSetupFailureIEs.List = append(nGSetupFailureIEs.List, ie)
-	if len(iesCriticalityDiagnostics.List) > 0 {
+	if criticalityDiagnostics != nil {
 		ie = ngapType.NGSetupFailureIEs{}
 		ie.Id.Value = ngapType.ProtocolIEIDCriticalityDiagnostics
-		ie.Criticality.Value = ngapType.CriticalityPresentNotify
-		ie.Value.Present = ngapType.NGSetupFailureIEsPresentCriticalityDiagnostics
+		ie.Criticality.Value = ngapType.CriticalityPresentIgnore
+		ie.Value.Present = ngapType.NGSetupResponseIEsPresentCriticalityDiagnostics
 		ie.Value.CriticalityDiagnostics = new(ngapType.CriticalityDiagnostics)
-		ie.Value.CriticalityDiagnostics.IEsCriticalityDiagnostics = iesCriticalityDiagnostics
+
+		ie.Value.CriticalityDiagnostics = criticalityDiagnostics
 		nGSetupFailureIEs.List = append(nGSetupFailureIEs.List, ie)
 	}
 

--- a/internal/ngap/message/send.go
+++ b/internal/ngap/message/send.go
@@ -92,14 +92,14 @@ func NasSendToRan(ue *context.AmfUe, accessType models.AccessType, packet []byte
 	return SendToRanUe(ranUe, packet)
 }
 
-func SendNGSetupResponse(ran *context.AmfRan) {
+func SendNGSetupResponse(ran *context.AmfRan, iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList) {
 	isNGSetupRespSent := false
 	additionalCause := ""
 	defer ngap_metrics.IncrMetricsSentMsg(ngap_metrics.NG_SETUP_RESPONSE, &isNGSetupRespSent, emptyCause, &additionalCause)
 
 	ran.Log.Info("Send NG-Setup response")
 
-	pkt, err := BuildNGSetupResponse()
+	pkt, err := BuildNGSetupResponse(iesCriticalityDiagnostics)
 	if err != nil {
 		additionalCause = ngap_metrics.NGAP_MSG_BUILD_ERR
 		ran.Log.Errorf("Build NGSetupResponse failed : %s", err.Error())
@@ -109,7 +109,7 @@ func SendNGSetupResponse(ran *context.AmfRan) {
 	isNGSetupRespSent, additionalCause = SendToRan(ran, pkt)
 }
 
-func SendNGSetupFailure(ran *context.AmfRan, cause ngapType.Cause) {
+func SendNGSetupFailure(ran *context.AmfRan, cause ngapType.Cause, iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList) {
 	isNGSetupFailSent := false
 	additionalCause := ""
 	defer ngap_metrics.IncrMetricsSentMsg(ngap_metrics.NG_SETUP_FAILURE, &isNGSetupFailSent, cause, &additionalCause)
@@ -122,7 +122,7 @@ func SendNGSetupFailure(ran *context.AmfRan, cause ngapType.Cause) {
 		return
 	}
 
-	pkt, err := BuildNGSetupFailure(cause)
+	pkt, err := BuildNGSetupFailure(cause, iesCriticalityDiagnostics)
 	if err != nil {
 		additionalCause = ngap_metrics.NGAP_MSG_BUILD_ERR
 		ran.Log.Errorf("Build NGSetupFailure failed : %s", err.Error())

--- a/internal/ngap/message/send.go
+++ b/internal/ngap/message/send.go
@@ -109,7 +109,11 @@ func SendNGSetupResponse(ran *context.AmfRan, iesCriticalityDiagnostics *ngapTyp
 	isNGSetupRespSent, additionalCause = SendToRan(ran, pkt)
 }
 
-func SendNGSetupFailure(ran *context.AmfRan, cause ngapType.Cause, iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList) {
+func SendNGSetupFailure(
+	ran *context.AmfRan,
+	cause ngapType.Cause,
+	iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList,
+) {
 	isNGSetupFailSent := false
 	additionalCause := ""
 	defer ngap_metrics.IncrMetricsSentMsg(ngap_metrics.NG_SETUP_FAILURE, &isNGSetupFailSent, cause, &additionalCause)

--- a/internal/ngap/message/send.go
+++ b/internal/ngap/message/send.go
@@ -92,14 +92,14 @@ func NasSendToRan(ue *context.AmfUe, accessType models.AccessType, packet []byte
 	return SendToRanUe(ranUe, packet)
 }
 
-func SendNGSetupResponse(ran *context.AmfRan, iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList) {
+func SendNGSetupResponse(ran *context.AmfRan, criticalityDiagnostics *ngapType.CriticalityDiagnostics) {
 	isNGSetupRespSent := false
 	additionalCause := ""
 	defer ngap_metrics.IncrMetricsSentMsg(ngap_metrics.NG_SETUP_RESPONSE, &isNGSetupRespSent, emptyCause, &additionalCause)
 
 	ran.Log.Info("Send NG-Setup response")
 
-	pkt, err := BuildNGSetupResponse(iesCriticalityDiagnostics)
+	pkt, err := BuildNGSetupResponse(criticalityDiagnostics)
 	if err != nil {
 		additionalCause = ngap_metrics.NGAP_MSG_BUILD_ERR
 		ran.Log.Errorf("Build NGSetupResponse failed : %s", err.Error())
@@ -112,7 +112,7 @@ func SendNGSetupResponse(ran *context.AmfRan, iesCriticalityDiagnostics *ngapTyp
 func SendNGSetupFailure(
 	ran *context.AmfRan,
 	cause ngapType.Cause,
-	iesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList,
+	criticalityDiagnostics *ngapType.CriticalityDiagnostics,
 ) {
 	isNGSetupFailSent := false
 	additionalCause := ""
@@ -126,7 +126,7 @@ func SendNGSetupFailure(
 		return
 	}
 
-	pkt, err := BuildNGSetupFailure(cause, iesCriticalityDiagnostics)
+	pkt, err := BuildNGSetupFailure(cause, criticalityDiagnostics)
 	if err != nil {
 		additionalCause = ngap_metrics.NGAP_MSG_BUILD_ERR
 		ran.Log.Errorf("Build NGSetupFailure failed : %s", err.Error())

--- a/internal/ngap/ngap_generator.go
+++ b/internal/ngap/ngap_generator.go
@@ -399,7 +399,7 @@ syntaxCause = &ngapType.Cause{
 
 		// Generate Error Indication
 		fmt.Fprintln(fOut, "")
-		fmt.Fprintln(fOut, "if syntaxCause != nil || len(iesCriticalityDiagnostics.List) > 0 {")
+		genErrorActionCondition(fOut, msgName)
 		fmt.Fprintln(fOut, "ran.Log.Trace(\"Has IE error\")")
 		genErrorIndicationCommon(fOut, mInfo)
 		fmt.Fprintln(fOut, "var pIesCriticalityDiagnostics *ngapType.CriticalityDiagnosticsIEList")
@@ -431,7 +431,7 @@ syntaxCause = &ngapType.Cause{
 
 		case "NGSetupRequest":
 			avoidNilSyntaxCause(fOut)
-			fmt.Fprintf(fOut, "if abort {\n	rawSendNGSetupFailure(ran, *syntaxCause, nil, &criticalityDiagnostics)\n}\n")
+			fmt.Fprintf(fOut, "rawSendNGSetupFailure(ran, *syntaxCause, nil, &criticalityDiagnostics)\n")
 
 		// Cannot fill mandatory IEs
 		// case "PathSwitchRequest":
@@ -533,7 +533,7 @@ syntaxCause = &ngapType.Cause{
 			}
 		}
 
-		if msgName == "NGSetupRequest" {
+		if msgName == "NGSetupRequest" || msgName == "RANConfigurationUpdate" {
 			mayNil := " /* may be nil */"
 			ieVar := "&iesCriticalityDiagnostics"
 			ieType := "ngapType.CriticalityDiagnosticsIEList"
@@ -820,6 +820,15 @@ func genErrorIndicationCommon(f io.Writer, mInfo *MsgInfo) {
 		fmt.Fprintln(f, "procedureCriticality := ngapType.CriticalityPresentIgnore")
 	case ngapType.CriticalityPresentNotify:
 		fmt.Fprintln(f, "procedureCriticality := ngapType.CriticalityPresentNotify")
+	}
+}
+
+func genErrorActionCondition(f io.Writer, msgName string) {
+	switch msgName {
+	case "NGSetupRequest", "RANConfigurationUpdate":
+		fmt.Fprintln(f, "if abort {")
+	default:
+		fmt.Fprintln(f, "if syntaxCause != nil || len(iesCriticalityDiagnostics.List) > 0 {")
 	}
 }
 

--- a/internal/ngap/ngap_generator.go
+++ b/internal/ngap/ngap_generator.go
@@ -448,11 +448,17 @@ syntaxCause = &ngapType.Cause{
 		default:
 			fmt.Fprintf(fOut, "ngap_message.SendErrorIndication(ran, %s, %s, syntaxCause, &criticalityDiagnostics)\n", amfIdIeVar, ranIdIeVar)
 		}
-		fmt.Fprintln(fOut, "}")
-		fmt.Fprintln(fOut, "")
-		fmt.Fprintln(fOut, "if abort {")
-		fmt.Fprintln(fOut, "return")
-		fmt.Fprintln(fOut, "}")
+		if msgName != "NGSetupRequest" && msgName != "RANConfigurationUpdate" {
+			fmt.Fprintln(fOut, "}")
+			fmt.Fprintln(fOut, "")
+			fmt.Fprintln(fOut, "if abort {")
+			fmt.Fprintln(fOut, "return")
+			fmt.Fprintln(fOut, "}")
+		} else {
+			fmt.Fprintln(fOut, "return")
+			fmt.Fprintln(fOut, "}")
+			fmt.Fprintln(fOut, "")
+		}
 
 		// To avoid Coverity's false positive, generate this check for Request messages too
 		fmt.Fprintln(fOut, "")

--- a/internal/ngap/ngap_generator.go
+++ b/internal/ngap/ngap_generator.go
@@ -431,7 +431,7 @@ syntaxCause = &ngapType.Cause{
 
 		case "NGSetupRequest":
 			avoidNilSyntaxCause(fOut)
-			fmt.Fprintf(fOut, "rawSendNGSetupFailure(ran, *syntaxCause, nil, &criticalityDiagnostics)\n")
+			fmt.Fprintf(fOut, "if abort {\n	rawSendNGSetupFailure(ran, *syntaxCause, nil, &criticalityDiagnostics)\n}\n")
 
 		// Cannot fill mandatory IEs
 		// case "PathSwitchRequest":
@@ -531,6 +531,14 @@ syntaxCause = &ngapType.Cause{
 				mainFuncArgDefs = append(mainFuncArgDefs, fmt.Sprintf("%s *%s", ieInfo.GoVar, ieInfo.GoType))
 				mainFuncArgs = append(mainFuncArgs, ieInfo.GoVar+mayNil)
 			}
+		}
+
+		if msgName == "NGSetupRequest" {
+			mayNil := " /* may be nil */"
+			ieVar := "&iesCriticalityDiagnostics"
+			ieType := "ngapType.CriticalityDiagnosticsIEList"
+			mainFuncArgDefs = append(mainFuncArgDefs, fmt.Sprintf("%s *%s", ieVar, ieType))
+			mainFuncArgs = append(mainFuncArgs, ieVar+mayNil)
 		}
 
 		fmt.Fprintln(fOut, "")

--- a/internal/sbi/processor/ue_context.go
+++ b/internal/sbi/processor/ue_context.go
@@ -39,6 +39,7 @@ func (p *Processor) CreateUEContextProcedure(ueContextID string, createUeContext
 	ueContextCreateData := createUeContextRequest.JsonData
 
 	if ueContextCreateData.UeContext == nil || ueContextCreateData.TargetId == nil ||
+		ueContextCreateData.TargetId.RanNodeId == nil || ueContextCreateData.TargetId.Tai == nil ||
 		ueContextCreateData.PduSessionList == nil || ueContextCreateData.SourceToTargetData == nil ||
 		ueContextCreateData.N2NotifyUri == "" {
 		ueCtxCreateError := models.UeContextCreateError{


### PR DESCRIPTION
`PUT /namf-comm/v1/ue-contexts/{ueContextId}` panics when `targetId` is present but its mandatory nested fields (`ranNodeId`, `tai`) are omitted — the top-level `TargetId != nil` guard passes, `NewAmfUe` runs, then the handler dereferences nil pointers causing a 500 DoS.

## Change

- **`internal/sbi/processor/ue_context.go`** — extend the existing early-return validation to also reject requests where `TargetId.RanNodeId` or `TargetId.Tai` is nil, per TS 29.518 (both are mandatory fields of `NgRanTargetId`):

```go
// Before
if ueContextCreateData.UeContext == nil || ueContextCreateData.TargetId == nil ||
    ueContextCreateData.PduSessionList == nil || ...

// After
if ueContextCreateData.UeContext == nil || ueContextCreateData.TargetId == nil ||
    ueContextCreateData.TargetId.RanNodeId == nil || ueContextCreateData.TargetId.Tai == nil ||
    ueContextCreateData.PduSessionList == nil || ...
```

Malformed requests (e.g. `"targetId": {}`) now return **403 HANDOVER_FAILURE** before any UE context is allocated.