### PR TITLE
fix(gmm/handler): reject EAP-AKA' AuthenticationResponse with no EAPMessage

### DIFF
--- a/internal/gmm/handler.go
+++ b/internal/gmm/handler.go
@@ -2054,6 +2054,19 @@ func HandleAuthenticationResponse(ue *context.AmfUe, accessType models.AccessTyp
 			}
 		}
 	case models.AusfUeAuthenticationAuthType_EAP_AKA_PRIME:
+		// EAPMessage (IEI 0x78) is an optional IE in the NAS
+		// AuthenticationResponse message. An attacker that knows a valid
+		// EAP-AKA'-configured SUCI can omit the IE; the NAS decoder then
+		// leaves EAPMessage as nil and the next line panicked before the
+		// UE had proven its identity (free5gc/free5gc#980).
+		if authenticationResponse.EAPMessage == nil {
+			ue.GmmLog.Errorln("EAP-AKA' AuthenticationResponse missing mandatory EAPMessage; rejecting")
+			gmm_message.SendAuthenticationReject(ue.RanUe[accessType], "", 0, nasMetrics.AUSF_AUTH_ERR)
+			return GmmFSM.SendEvent(ue.State[accessType], AuthFailEvent, fsm.ArgsType{
+				ArgAmfUe:      ue,
+				ArgAccessType: accessType,
+			}, logger.GmmLog)
+		}
 		response, pd, err := consumer.GetConsumer().SendEapAuthConfirmRequest(ue, *authenticationResponse.EAPMessage)
 		if err != nil {
 			return err

--- a/internal/gmm/handler.go
+++ b/internal/gmm/handler.go
@@ -2054,11 +2054,8 @@ func HandleAuthenticationResponse(ue *context.AmfUe, accessType models.AccessTyp
 			}
 		}
 	case models.AusfUeAuthenticationAuthType_EAP_AKA_PRIME:
-		// EAPMessage (IEI 0x78) is an optional IE in the NAS
-		// AuthenticationResponse message. An attacker that knows a valid
-		// EAP-AKA'-configured SUCI can omit the IE; the NAS decoder then
-		// leaves EAPMessage as nil and the next line panicked before the
-		// UE had proven its identity (free5gc/free5gc#980).
+		// EAPMessage IE is optional in the NAS-AuthenticationResponse;
+		// reject the UE if it is omitted instead of dereferencing nil.
 		if authenticationResponse.EAPMessage == nil {
 			ue.GmmLog.Errorln("EAP-AKA' AuthenticationResponse missing mandatory EAPMessage; rejecting")
 			gmm_message.SendAuthenticationReject(ue.RanUe[accessType], "", 0, nasMetrics.AUSF_AUTH_ERR)


### PR DESCRIPTION
## Summary

`HandleAuthenticationResponse` dereferences `*authenticationResponse.EAPMessage` on the EAP-AKA' path without a nil guard. `EAPMessage` (IEI 0x78) is an **optional** IE in the NAS AuthenticationResponse message, so an attacker that knows a valid EAP-AKA'-configured SUCI can omit the IE; the decoder leaves `EAPMessage` as nil and the next line (`*authenticationResponse.EAPMessage`) panics, killing the AMF NGAP worker goroutine **before** the UE has proven its identity.

## Fix

Check for nil and reject the authentication cleanly via `SendAuthenticationReject` + `AuthFailEvent` so the AMF process survives and the state machine returns to deregistered.

Fixes free5gc/free5gc#980.

## Test

- `go build ./internal/gmm/...` green.
- `gofmt` clean.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
