### PR TITLE
fix(sbi/consumer): nil-check JsonData on UEContextTransfer 200 response

### DIFF
--- a/internal/sbi/consumer/amf_service.go
+++ b/internal/sbi/consumer/amf_service.go
@@ -291,6 +291,7 @@ func (s *namfService) UEContextTransferRequest(
 		ueContextTransferRspData = res.UeContextTransferResponse200.JsonData
 		if ueContextTransferRspData == nil {
 			logger.ConsumerLog.Warnln("UeContextTransfer 200 response missing JsonData")
+			problemDetails = openapi.ProblemDetailsSystemFailure("invalid UE context transfer response: missing response data")
 			err = openapi.ReportError("UeContextTransfer 200 missing JsonData")
 			return ueContextTransferRspData, problemDetails, err
 		}

--- a/internal/sbi/consumer/amf_service.go
+++ b/internal/sbi/consumer/amf_service.go
@@ -289,6 +289,11 @@ func (s *namfService) UEContextTransferRequest(
 			return ueContextTransferRspData, problemDetails, err
 		}
 		ueContextTransferRspData = res.UeContextTransferResponse200.JsonData
+		if ueContextTransferRspData == nil {
+			logger.ConsumerLog.Warnln("UeContextTransfer 200 response missing JsonData")
+			err = openapi.ReportError("UeContextTransfer 200 missing JsonData")
+			return ueContextTransferRspData, problemDetails, err
+		}
 		if ueContextTransferRspData.UeContext == nil {
 			problemDetails = openapi.ProblemDetailsSystemFailure("invalid UE context transfer response: missing UE context")
 			return ueContextTransferRspData, problemDetails, err


### PR DESCRIPTION
Fixes free5gc/free5gc#1045.

`UEContextTransferRequest` indexed `res.UeContextTransferResponse200.JsonData` and immediately dereferenced it for the debug log, but `JsonData` is `*UeContextTransferRspData,omitempty` in the OpenAPI model. A source AMF returning a syntactically-valid 200 OK with the `jsonData` part absent, picked `application/json` over `multipart/related`, or sent an empty body, reached here with the pointer nil and the deref panicked the target AMF during cross-AMF UE mobility / 5G-GUTI re-registration.

Guard the deref and surface a clear `UeContextTransfer 200 missing JsonData` error so the caller can fall through to the foreign-GUAMI handling path instead of crashing.