### PR TITLE
fix(ngap): guard nil GNbId and missing targetRan in UplinkRANConfigurationTransfer

### DIFF
--- a/internal/ngap/handler.go
+++ b/internal/ngap/handler.go
@@ -1911,7 +1911,7 @@ func handleUplinkRANConfigurationTransferMain(ran *context.AmfRan,
 	if sONConfigurationTransferUL != nil {
 		targetRanNodeID := ngapConvert.RanIdToModels(sONConfigurationTransferUL.TargetRANNodeID.GlobalRANNodeID)
 
-		if targetRanNodeID.GNbId.GNBValue != "" {
+		if targetRanNodeID.GNbId != nil && targetRanNodeID.GNbId.GNBValue != "" {
 			ran.Log.Tracef("targerRanID [%s]", targetRanNodeID.GNbId.GNBValue)
 		}
 
@@ -1919,7 +1919,8 @@ func handleUplinkRANConfigurationTransferMain(ran *context.AmfRan,
 
 		targetRan, ok := aMFSelf.AmfRanFindByRanID(targetRanNodeID)
 		if !ok {
-			ran.Log.Warn("targetRan is nil")
+			ran.Log.Warn("targetRan not found, dropping SONConfigurationTransfer")
+			return
 		}
 
 		ngap_message.SendDownlinkRanConfigurationTransfer(targetRan, sONConfigurationTransferUL)


### PR DESCRIPTION
## Summary

Fixes **free5gc/free5gc#1049** — nil pointer dereference in the AMF NGAP handler for `UplinkRANConfigurationTransfer`.

## Root Cause

The function `handleUplinkRANConfigurationTransferMain` contained two bugs:

### Bug 1 — nil dereference on `GNbId` (line 1914)

`ngapConvert.RanIdToModels()` only sets `ranId.GNbId` when the incoming
`GlobalRANNodeID` carries a **global gNB-ID** (`GlobalRANNodeIDPresentGlobalGNBID`).
For any other node type — `globalN3IWF-ID`, `globalNgENB-ID`, `globalTNGF-ID`,
`globalTWIF-ID`, `globalWAGF-ID` — the field is left `nil`.

The handler then unconditionally accessed `targetRanNodeID.GNbId.GNBValue`,
causing a nil-pointer dereference panic.

```go
// BEFORE (panics when GNbId is nil)
if targetRanNodeID.GNbId.GNBValue != "" {
    ran.Log.Tracef("targerRanID [%s]", targetRanNodeID.GNbId.GNBValue)
}

// AFTER
if targetRanNodeID.GNbId != nil && targetRanNodeID.GNbId.GNBValue != "" {
    ran.Log.Tracef("targerRanID [%s]", targetRanNodeID.GNbId.GNBValue)
}
```

### Bug 2 — nil `targetRan` passed to `SendDownlinkRanConfigurationTransfer`

When `AmfRanFindByRanID` returns `ok = false`, `targetRan` is `nil`. The previous
code logged a warning but continued to call
`SendDownlinkRanConfigurationTransfer(targetRan, ...)` with the nil pointer,
risking a secondary panic inside that function.

```go
// BEFORE
targetRan, ok := aMFSelf.AmfRanFindByRanID(targetRanNodeID)
if !ok {
    ran.Log.Warn("targetRan is nil")
}
ngap_message.SendDownlinkRanConfigurationTransfer(targetRan, sONConfigurationTransferUL)

// AFTER
targetRan, ok := aMFSelf.AmfRanFindByRanID(targetRanNodeID)
if !ok {
    ran.Log.Warn("targetRan not found, dropping SONConfigurationTransfer")
    return
}
ngap_message.SendDownlinkRanConfigurationTransfer(targetRan, sONConfigurationTransferUL)
```

## How to Reproduce

Send a crafted NGAP `UplinkRANConfigurationTransfer` message where
`TargetRANNodeID.GlobalRANNodeID` uses a non-gNB node type
(e.g. `globalN3IWF-ID`), or a valid gNB ID that does not match any known RAN.
The AMF process panics immediately.

## Changes

- `internal/ngap/handler.go`: Add `GNbId != nil` guard before accessing
  `GNbId.GNBValue`; add early `return` when `targetRan` is not found.