### PR TITLE
fix: guard non-string DNN type assertions in GMM handler

### DIFF
--- a/internal/gmm/handler.go
+++ b/internal/gmm/handler.go
@@ -255,7 +255,12 @@ func CreatePDUSession(ulNasTransport *nasMessage.ULNASTransport,
 			if snssaiInfo, ok := ue.SmfSelectionData.SubscribedSnssaiInfos[snssaiStr]; ok {
 				for _, dnnInfo := range snssaiInfo.DnnInfos {
 					if dnnInfo.DefaultDnnIndicator {
-						dnn = dnnInfo.Dnn.(string)
+						dnnStr, isStr := dnnInfo.Dnn.(string)
+						if !isStr {
+							ue.GmmLog.Warnf("skip DNN with non-string type %T: %v", dnnInfo.Dnn, dnnInfo.Dnn)
+							continue
+						}
+						dnn = dnnStr
 					}
 				}
 			}
@@ -1295,7 +1300,12 @@ func assignLadnInfo(ue *context.AmfUe, accessType models.AccessType) {
 			} else {
 				for _, snssaiInfos := range ue.SmfSelectionData.SubscribedSnssaiInfos {
 					for _, dnnInfo := range snssaiInfos.DnnInfos {
-						if ladn, ok := amfSelf.LadnPool[dnnInfo.Dnn.(string)]; ok { // check if this dnn is a ladn
+						dnnStr, isStr := dnnInfo.Dnn.(string)
+						if !isStr {
+							ue.GmmLog.Warnf("skip DNN with non-string type %T: %v", dnnInfo.Dnn, dnnInfo.Dnn)
+							continue
+						}
+						if ladn, ok := amfSelf.LadnPool[dnnStr]; ok { // check if this dnn is a ladn
 							if ue.TaiListInRegistrationArea(ladn.TaiList, accessType) {
 								ue.LadnInfo = append(ue.LadnInfo, ladn)
 							}
@@ -1316,8 +1326,13 @@ func assignLadnInfo(ue *context.AmfUe, accessType models.AccessType) {
 	} else if ue.SmfSelectionData != nil {
 		for _, snssaiInfos := range ue.SmfSelectionData.SubscribedSnssaiInfos {
 			for _, dnnInfo := range snssaiInfos.DnnInfos {
-				if dnnInfo.Dnn != "*" {
-					if ladn, ok := amfSelf.LadnPool[dnnInfo.Dnn.(string)]; ok {
+				dnnStr, isStr := dnnInfo.Dnn.(string)
+				if !isStr {
+					ue.GmmLog.Warnf("skip DNN with non-string type %T: %v", dnnInfo.Dnn, dnnInfo.Dnn)
+					continue
+				}
+				if dnnStr != "*" {
+					if ladn, ok := amfSelf.LadnPool[dnnStr]; ok {
 						if ue.TaiListInRegistrationArea(ladn.TaiList, accessType) {
 							ue.LadnInfo = append(ue.LadnInfo, ladn)
 						}

--- a/internal/gmm/handler_test.go
+++ b/internal/gmm/handler_test.go
@@ -1,0 +1,51 @@
+package gmm
+
+import (
+	"testing"
+
+	"github.com/free5gc/amf/internal/context"
+	"github.com/free5gc/amf/internal/logger"
+	"github.com/free5gc/nas/nasMessage"
+	"github.com/free5gc/openapi/models"
+)
+
+// TestAssignLadnInfoNonStringDnn is a regression test for free5gc/free5gc#1071.
+// A subscriber whose DNN was provisioned as a JSON number is unmarshalled into
+// models.DnnInfo.Dnn (typed interface{}) as a float64. The former bare
+// dnnInfo.Dnn.(string) assertions in assignLadnInfo panicked on such a value,
+// which the NGAP worker's recover turned into a permanent worker death (DoS).
+// assignLadnInfo must now skip non-string DNN entries instead of panicking.
+func TestAssignLadnInfoNonStringDnn(t *testing.T) {
+	tests := []struct {
+		name string
+		dnn  interface{}
+	}{
+		{name: "numeric DNN (float64) does not panic", dnn: float64(123456)},
+		{name: "valid string DNN is handled normally", dnn: "internet"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ue := &context.AmfUe{}
+			ue.GmmLog = logger.GmmLog
+			// LADNIndication left nil so control reaches the else-if
+			// SmfSelectionData branch containing the reported sink.
+			ue.RegistrationRequest = &nasMessage.RegistrationRequest{}
+			ue.SmfSelectionData = &models.SmfSelectionSubscriptionData{
+				SubscribedSnssaiInfos: map[string]models.SnssaiInfo{
+					"01010203": {
+						DnnInfos: []models.DnnInfo{{Dnn: tc.dnn}},
+					},
+				},
+			}
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("assignLadnInfo panicked on DNN %v (%T): %v", tc.dnn, tc.dnn, r)
+				}
+			}()
+
+			assignLadnInfo(ue, models.AccessType__3_GPP_ACCESS)
+		})
+	}
+}


### PR DESCRIPTION
A subscriber DNN provisioned as a JSON number is unmarshalled into models.DnnInfo.Dnn (interface{}) as a float64. The bare dnnInfo.Dnn.(string) assertions in CreatePDUSession and assignLadnInfo panicked on such a value; the NGAP worker's recover then let the worker goroutine exit permanently, denying NGAP processing to its UE subset.

Use comma-ok assertions and skip (log + continue) any non-string DNN entry instead of asserting. Also assert before the "*" comparison so a numeric DNN can no longer fall through to a bare assertion.

Fixes the AMF portion of free5gc/free5gc#1071.