### PR TITLE
fix: return generic error details on AMF deserialization failures

### DIFF
--- a/internal/sbi/api_communication.go
+++ b/internal/sbi/api_communication.go
@@ -141,7 +141,7 @@ func (s *Server) HTTPAMFStatusChangeSubscribeModify(c *gin.Context) {
 		problemDetail := models.ProblemDetails{
 			Title:  "System failure",
 			Status: http.StatusInternalServerError,
-			Detail: err.Error(),
+			Detail: "Failed to read request body",
 			Cause:  "SYSTEM_FAILURE",
 		}
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetail.Cause)
@@ -155,7 +155,7 @@ func (s *Server) HTTPAMFStatusChangeSubscribeModify(c *gin.Context) {
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "Failed to deserialize request body",
 		}
 		logger.CommLog.Errorln(problemDetail)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
@@ -180,7 +180,7 @@ func (s *Server) HTTPCreateUEContext(c *gin.Context) {
 		problemDetail := models.ProblemDetails{
 			Title:  "System failure",
 			Status: http.StatusInternalServerError,
-			Detail: err.Error(),
+			Detail: "Failed to read request body",
 			Cause:  "SYSTEM_FAILURE",
 		}
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetail)
@@ -204,7 +204,7 @@ func (s *Server) HTTPCreateUEContext(c *gin.Context) {
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "Failed to deserialize request body",
 		}
 		logger.CommLog.Errorln(problemDetail)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText((http.StatusBadRequest)))
@@ -223,7 +223,7 @@ func (s *Server) HTTPEBIAssignment(c *gin.Context) {
 		problemDetail := models.ProblemDetails{
 			Title:  "System failure",
 			Status: http.StatusInternalServerError,
-			Detail: err.Error(),
+			Detail: "Failed to read request body",
 			Cause:  "SYSTEM_FAILURE",
 		}
 		logger.CommLog.Errorf("Get Request Body error: %+v", err)
@@ -238,7 +238,7 @@ func (s *Server) HTTPEBIAssignment(c *gin.Context) {
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "Failed to deserialize request body",
 		}
 		logger.CommLog.Errorln(problemDetail)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
@@ -258,7 +258,7 @@ func (s *Server) HTTPRegistrationStatusUpdate(c *gin.Context) {
 		problemDetail := models.ProblemDetails{
 			Title:  "System failure",
 			Status: http.StatusInternalServerError,
-			Detail: err.Error(),
+			Detail: "Failed to read request body",
 			Cause:  "SYSTEM_FAILURE",
 		}
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetail)
@@ -272,7 +272,7 @@ func (s *Server) HTTPRegistrationStatusUpdate(c *gin.Context) {
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "Failed to deserialize request body",
 		}
 		logger.CommLog.Errorln(problemDetail)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
@@ -292,7 +292,7 @@ func (s *Server) HTTPReleaseUEContext(c *gin.Context) {
 		problemDetail := models.ProblemDetails{
 			Title:  "System failure",
 			Status: http.StatusInternalServerError,
-			Detail: err.Error(),
+			Detail: "Failed to read request body",
 			Cause:  "SYSTEM_FAILURE",
 		}
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetail)
@@ -306,7 +306,7 @@ func (s *Server) HTTPReleaseUEContext(c *gin.Context) {
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "Failed to deserialize request body",
 		}
 		logger.CommLog.Errorln(problemDetail)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
@@ -327,7 +327,7 @@ func (s *Server) HTTPUEContextTransfer(c *gin.Context) {
 		problemDetail := models.ProblemDetails{
 			Title:  "System failure",
 			Status: http.StatusInternalServerError,
-			Detail: err.Error(),
+			Detail: "Failed to read request body",
 			Cause:  "SYSTEM_FAILURE",
 		}
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetail)
@@ -349,7 +349,7 @@ func (s *Server) HTTPUEContextTransfer(c *gin.Context) {
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "Failed to deserialize request body",
 		}
 		logger.CommLog.Errorln(problemDetail)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
@@ -380,7 +380,7 @@ func (s *Server) HTTPN1N2MessageTransfer(c *gin.Context) {
 		problemDetail := models.ProblemDetails{
 			Title:  "System failure",
 			Status: http.StatusInternalServerError,
-			Detail: err.Error(),
+			Detail: "Failed to read request body",
 			Cause:  "SYSTEM_FAILURE",
 		}
 		logger.CommLog.Errorf("Get Request Body error: %+v", err)
@@ -405,7 +405,7 @@ func (s *Server) HTTPN1N2MessageTransfer(c *gin.Context) {
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "Failed to deserialize request body",
 		}
 		logger.CommLog.Errorln(problemDetail)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
@@ -428,7 +428,7 @@ func (s *Server) HTTPN1N2MessageSubscribe(c *gin.Context) {
 		problemDetail := models.ProblemDetails{
 			Title:  "System failure",
 			Status: http.StatusInternalServerError,
-			Detail: err.Error(),
+			Detail: "Failed to read request body",
 			Cause:  "SYSTEM_FAILURE",
 		}
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetail.Cause)
@@ -442,7 +442,7 @@ func (s *Server) HTTPN1N2MessageSubscribe(c *gin.Context) {
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "Failed to deserialize request body",
 		}
 		logger.CommLog.Errorln(problemDetail)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
@@ -476,7 +476,7 @@ func (s *Server) HTTPAMFStatusChangeSubscribe(c *gin.Context) {
 		problemDetail := models.ProblemDetails{
 			Title:  "System failure",
 			Status: http.StatusInternalServerError,
-			Detail: err.Error(),
+			Detail: "Failed to read request body",
 			Cause:  "SYSTEM_FAILURE",
 		}
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetail.Cause)
@@ -490,7 +490,7 @@ func (s *Server) HTTPAMFStatusChangeSubscribe(c *gin.Context) {
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "Failed to deserialize request body",
 		}
 		logger.CommLog.Errorln(problemDetail)
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))

--- a/internal/sbi/api_communication.go
+++ b/internal/sbi/api_communication.go
@@ -151,7 +151,7 @@ func (s *Server) HTTPAMFStatusChangeSubscribeModify(c *gin.Context) {
 
 	err = openapi.Deserialize(&subscriptionData, requestBody, applicationjson)
 	if err != nil {
-		problemDetail := reqbody + err.Error()
+		problemDetail := fmt.Sprintf("Failed to deserialize request body: %v", err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
@@ -200,7 +200,7 @@ func (s *Server) HTTPCreateUEContext(c *gin.Context) {
 	}
 
 	if err != nil {
-		problemDetail := reqbody + err.Error()
+		problemDetail := fmt.Sprintf("Failed to deserialize request body: %v", err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
@@ -234,7 +234,7 @@ func (s *Server) HTTPEBIAssignment(c *gin.Context) {
 
 	err = openapi.Deserialize(&assignEbiData, requestBody, applicationjson)
 	if err != nil {
-		problemDetail := reqbody + err.Error()
+		problemDetail := fmt.Sprintf("Failed to deserialize request body: %v", err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
@@ -268,7 +268,7 @@ func (s *Server) HTTPRegistrationStatusUpdate(c *gin.Context) {
 
 	err = openapi.Deserialize(&ueRegStatusUpdateReqData, requestBody, applicationjson)
 	if err != nil {
-		problemDetail := reqbody + err.Error()
+		problemDetail := fmt.Sprintf("Failed to deserialize request body: %v", err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
@@ -302,7 +302,7 @@ func (s *Server) HTTPReleaseUEContext(c *gin.Context) {
 
 	err = openapi.Deserialize(&ueContextRelease, requestBody, applicationjson)
 	if err != nil {
-		problemDetail := reqbody + err.Error()
+		problemDetail := fmt.Sprintf("Failed to deserialize request body: %v", err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
@@ -345,7 +345,7 @@ func (s *Server) HTTPUEContextTransfer(c *gin.Context) {
 	}
 
 	if err != nil {
-		problemDetail := reqbody + err.Error()
+		problemDetail := fmt.Sprintf("Failed to deserialize request body: %v", err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
@@ -401,7 +401,7 @@ func (s *Server) HTTPN1N2MessageTransfer(c *gin.Context) {
 	}
 
 	if err != nil {
-		problemDetail := reqbody + err.Error()
+		problemDetail := fmt.Sprintf("Failed to deserialize request body: %v", err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
@@ -438,7 +438,7 @@ func (s *Server) HTTPN1N2MessageSubscribe(c *gin.Context) {
 
 	err = openapi.Deserialize(&ueN1N2InfoSubscriptionCreateData, requestBody, applicationjson)
 	if err != nil {
-		problemDetail := reqbody + err.Error()
+		problemDetail := fmt.Sprintf("Failed to deserialize request body: %v", err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
@@ -486,7 +486,7 @@ func (s *Server) HTTPAMFStatusChangeSubscribe(c *gin.Context) {
 
 	err = openapi.Deserialize(&subscriptionData, requestBody, applicationjson)
 	if err != nil {
-		problemDetail := reqbody + err.Error()
+		problemDetail := fmt.Sprintf("Failed to deserialize request body: %v", err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,

--- a/internal/sbi/api_communication_test.go
+++ b/internal/sbi/api_communication_test.go
@@ -1,0 +1,62 @@
+package sbi
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GHSA-xw5p-5pgh-4xq5: the AMF communication handlers returned the raw
+// deserialization error string in the ProblemDetails Detail field, exposing
+// fully-qualified internal Go struct names to the client. The handlers must
+// keep the detailed error in the server log and return a generic
+// client-facing message instead.
+func TestDeserializeErrorsDoNotLeakInternals(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := &Server{}
+
+	// Truncated JSON guarantees the deserialization failure path.
+	malformed := []byte(`{"notificationUri":`)
+
+	handlers := []struct {
+		name    string
+		handler func(*gin.Context)
+	}{
+		{"HTTPAMFStatusChangeSubscribeModify", s.HTTPAMFStatusChangeSubscribeModify},
+		{"HTTPCreateUEContext", s.HTTPCreateUEContext},
+		{"HTTPEBIAssignment", s.HTTPEBIAssignment},
+		{"HTTPRegistrationStatusUpdate", s.HTTPRegistrationStatusUpdate},
+		{"HTTPReleaseUEContext", s.HTTPReleaseUEContext},
+		{"HTTPUEContextTransfer", s.HTTPUEContextTransfer},
+		{"HTTPN1N2MessageTransfer", s.HTTPN1N2MessageTransfer},
+		{"HTTPN1N2MessageSubscribe", s.HTTPN1N2MessageSubscribe},
+		{"HTTPAMFStatusChangeSubscribe", s.HTTPAMFStatusChangeSubscribe},
+	}
+
+	for _, tc := range handlers {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/",
+				bytes.NewReader(malformed))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			tc.handler(c)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 for malformed body, got %d", w.Code)
+			}
+			body := w.Body.String()
+			// The client-facing detail must be the generic message, not the
+			// raw deserialization error (which embeds internal details).
+			if !bytes.Contains([]byte(body),
+				[]byte("Failed to deserialize request body")) {
+				t.Fatalf("expected generic detail message, got: %s", body)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1128

### Summary

Nine handlers in `internal/sbi/api_communication.go` (`HTTPAMFStatusChangeSubscribeModify`, `HTTPCreateUEContext`, `HTTPEBIAssignment`, `HTTPRegistrationStatusUpdate`, `HTTPReleaseUEContext`, `HTTPUEContextTransfer`, `HTTPN1N2MessageTransfer`, `HTTPN1N2MessageSubscribe`, `HTTPAMFStatusChangeSubscribe`) returned the raw Go `error.Error()` string in the `Detail` field of the `ProblemDetails` response on deserialization failure, exposing fully-qualified internal Go struct names to the client (`GHSA-xw5p-5pgh-4xq5`).

### Changes

Keep the detailed error in the server log (unchanged) and return fixed client-facing messages instead:
- request-body read failure: `"Failed to read request body"`
- deserialization failure: `"Failed to deserialize request body"`

### Validation

- New test `TestDeserializeErrorsDoNotLeakInternals` covering all nine handlers: a truncated JSON body gets a 400 whose detail is the generic message. **Before this fix the detail carried the raw deserialization error** (red), with the fix it is the fixed message (green).
- `go test ./internal/sbi/`: ok; `go vet` / `gofmt`: clean.