### PR TITLE
fix: reject unsupported Content-Type in HTTPUEContextTransfer

### DIFF
--- a/internal/sbi/api_communication.go
+++ b/internal/sbi/api_communication.go
@@ -342,6 +342,8 @@ func (s *Server) HTTPUEContextTransfer(c *gin.Context) {
 		err = openapi.Deserialize(ueContextTransferRequest.JsonData, requestBody, contentType)
 	case multipartrelate:
 		err = openapi.Deserialize(&ueContextTransferRequest, requestBody, contentType)
+	default:
+		err = fmt.Errorf("wrong content type")
 	}
 
 	if err != nil {

--- a/internal/sbi/api_content_type_test.go
+++ b/internal/sbi/api_content_type_test.go
@@ -1,0 +1,33 @@
+package sbi
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CVE-2026-41136: HTTPUEContextTransfer's Content-Type switch had no
+// default case. An unsupported Content-Type left err nil, skipped the
+// deserialization-error check, and invoked the processor with a
+// completely uninitialized UeContextTransferRequest. Mirror the default
+// case used by the analogous handlers (HTTPCreateUEContext).
+func TestUEContextTransferRejectsUnsupportedContentType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := &Server{}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/",
+		bytes.NewReader([]byte(`{}`)))
+	c.Request.Header.Set("Content-Type", "text/plain")
+
+	s.HTTPUEContextTransfer(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unsupported content type, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
Fixes #1120

### Summary

The Content-Type switch in `HTTPUEContextTransfer` covered only `application/json` and `multipart/related` with no default case. An unsupported Content-Type left `err` nil, skipped the deserialization-error check, and invoked the processor with a completely uninitialized `UeContextTransferRequest` (CVE-2026-41136) — inconsistent with the analogous handlers in the same file.

### Changes

Add the same default case used by `HTTPCreateUEContext` and `HTTPN1N2MessageTransfer`: unsupported Content-Type sets `err = fmt.Errorf("wrong content type")` and returns 400.

### Validation

- New test `TestUEContextTransferRejectsUnsupportedContentType`: a POST with `text/plain` gets 400. **Before the fix the handler fell through and crashed in the (uninitialized) processor call** (red), with the fix it returns 400 (green).
- `go test ./internal/sbi/`: ok; `go vet` / `gofmt`: clean.