### PR TITLE
fix(sbi): avoid leaking Go types in malformed request errors

### DIFF
--- a/internal/sbi/api_communication.go
+++ b/internal/sbi/api_communication.go
@@ -156,9 +156,11 @@ func (s *Server) HTTPAMFStatusChangeSubscribeModify(c *gin.Context) {
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
 			Detail: "Failed to deserialize request body",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
 		logger.CommLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}
@@ -205,9 +207,11 @@ func (s *Server) HTTPCreateUEContext(c *gin.Context) {
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
 			Detail: "Failed to deserialize request body",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
 		logger.CommLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText((http.StatusBadRequest)))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}
@@ -239,9 +243,11 @@ func (s *Server) HTTPEBIAssignment(c *gin.Context) {
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
 			Detail: "Failed to deserialize request body",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
 		logger.CommLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}
@@ -273,9 +279,11 @@ func (s *Server) HTTPRegistrationStatusUpdate(c *gin.Context) {
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
 			Detail: "Failed to deserialize request body",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
 		logger.CommLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}
@@ -307,9 +315,11 @@ func (s *Server) HTTPReleaseUEContext(c *gin.Context) {
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
 			Detail: "Failed to deserialize request body",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
 		logger.CommLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}
@@ -350,9 +360,11 @@ func (s *Server) HTTPUEContextTransfer(c *gin.Context) {
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
 			Detail: "Failed to deserialize request body",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
 		logger.CommLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}
@@ -406,9 +418,11 @@ func (s *Server) HTTPN1N2MessageTransfer(c *gin.Context) {
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
 			Detail: "Failed to deserialize request body",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
 		logger.CommLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}
@@ -443,9 +457,11 @@ func (s *Server) HTTPN1N2MessageSubscribe(c *gin.Context) {
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
 			Detail: "Failed to deserialize request body",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
 		logger.CommLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}
@@ -491,9 +507,11 @@ func (s *Server) HTTPAMFStatusChangeSubscribe(c *gin.Context) {
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
 			Detail: "Failed to deserialize request body",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
 		logger.CommLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}

--- a/internal/sbi/api_eventexposure.go
+++ b/internal/sbi/api_eventexposure.go
@@ -66,14 +66,15 @@ func (s *Server) HTTPModifySubscription(c *gin.Context) {
 
 	err = openapi.Deserialize(&modifySubscriptionRequest, requestBody, "application/json")
 	if err != nil {
-		problemDetail := reqbody + err.Error()
+		logger.EeLog.Errorf("%s%+v", reqbody, err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "The request body is malformed or does not match the expected schema.",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
-		logger.EeLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}
@@ -99,14 +100,15 @@ func (s *Server) HTTPCreateSubscription(c *gin.Context) {
 
 	err = openapi.Deserialize(&createEventSubscription, requestBody, "application/json")
 	if err != nil {
-		problemDetail := reqbody + err.Error()
+		logger.EeLog.Errorf("%s%+v", reqbody, err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "The request body is malformed or does not match the expected schema.",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
-		logger.EeLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}

--- a/internal/sbi/api_httpcallback.go
+++ b/internal/sbi/api_httpcallback.go
@@ -73,14 +73,15 @@ func (s *Server) HTTPAmPolicyControlUpdateNotifyUpdate(c *gin.Context) {
 
 	err = openapi.Deserialize(&policyUpdate, requestBody, "application/json")
 	if err != nil {
-		problemDetail := reqbody + err.Error()
+		logger.CallbackLog.Errorf("%s%+v", reqbody, err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "The request body is malformed or does not match the expected schema.",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
-		logger.CallbackLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}
@@ -106,14 +107,15 @@ func (s *Server) HTTPAmPolicyControlUpdateNotifyTerminate(c *gin.Context) {
 
 	err = openapi.Deserialize(&terminationNotification, requestBody, "application/json")
 	if err != nil {
-		problemDetail := reqbody + err.Error()
+		logger.CallbackLog.Errorf("%s%+v", reqbody, err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "The request body is malformed or does not match the expected schema.",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
-		logger.CallbackLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}
@@ -126,14 +128,15 @@ func (s *Server) HTTPN1MessageNotify(c *gin.Context) {
 
 	err := c.ShouldBindWith(&n1MessageNotify, openapi.MultipartRelatedBinding{})
 	if err != nil {
-		problemDetail := reqbody + err.Error()
+		logger.CallbackLog.Errorf("%s%+v", reqbody, err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "The request body is malformed or does not match the expected schema.",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
-		logger.CallbackLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}
@@ -159,14 +162,15 @@ func (s *Server) HTTPSmContextStatusNotify(c *gin.Context) {
 
 	err = openapi.Deserialize(&smContextStatusNotification, requestBody, "application/json")
 	if err != nil {
-		problemDetail := "[Request Body] " + err.Error()
+		logger.CallbackLog.Errorf("%s%+v", reqbody, err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "The request body is malformed or does not match the expected schema.",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
-		logger.CallbackLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}
@@ -199,10 +203,12 @@ func (s *Server) HTTPHandleDeregistrationNotification(c *gin.Context) {
 		problemDetails := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: reqbody + err.Error(),
+			Detail: "The request body is malformed or does not match the expected schema.",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
-		logger.CallbackLog.Errorln(problemDetails.Detail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		logger.CallbackLog.Errorf("%s%+v", reqbody, err)
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, problemDetails.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, problemDetails)
 		return
 	}

--- a/internal/sbi/api_location.go
+++ b/internal/sbi/api_location.go
@@ -70,14 +70,15 @@ func (s *Server) HTTPProvideLocationInfo(c *gin.Context) {
 
 	err = openapi.Deserialize(&requestLocInfo, requestBody, "application/json")
 	if err != nil {
-		problemDetail := "[Request Body] " + err.Error()
+		logger.LocationLog.Errorf("%s%+v", reqbody, err)
 		rsp := models.ProblemDetails{
 			Title:  "Malformed request syntax",
 			Status: http.StatusBadRequest,
-			Detail: problemDetail,
+			Detail: "The request body is malformed or does not match the expected schema.",
+			Cause:  "INVALID_MSG_FORMAT",
 		}
-		logger.LocationLog.Errorln(problemDetail)
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(http.StatusBadRequest))
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, rsp.Cause)
+		c.Header("Content-Type", "application/problem+json")
 		c.JSON(http.StatusBadRequest, rsp)
 		return
 	}


### PR DESCRIPTION
## Related issue

This PR fixes [free5gc/free5gc#1128](https://github.com/free5gc/free5gc/issues/1128), where malformed SBI request responses expose internal Go model names in `ProblemDetails.detail`.

## Summary

When AMF receives a malformed SBI request body, the error response can expose internal Go model names such as `models.AssignEbiData`.

This change:

- replaces the exposed parser error with a generic client-facing message;
- keeps the detailed deserialization error in the AMF log;
- returns `400 Bad Request` with `cause: INVALID_MSG_FORMAT`;
- sets the response media type to `application/problem+json`.

The fix covers the Namf_Communication handlers from #1128 and the same error pattern in Namf_Location, Namf_EventExposure, and AMF callback handlers.

## Testing

- `go test ./internal/sbi/...` passes.
- `go test ./...` is currently affected by an unrelated timing-sensitive failure in `internal/context/TestTimerStartAndStop`: the test expected 3 expirations but observed fewer.

Fixes free5gc/free5gc#1128